### PR TITLE
Implement QvstBreadcrumb

### DIFF
--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/service/WordpressService.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/service/WordpressService.kt
@@ -42,6 +42,10 @@ interface WordpressService {
     ): String
 
     @Headers("Content-Type: application/json")
+    @GET("xpeho/v1/qvst/campaigns")
+    suspend fun getAllQvstCampaigns(): List<QvstCampaign>
+
+    @Headers("Content-Type: application/json")
     @GET("xpeho/v1/qvst/campaigns:active")
     suspend fun getQvstCampaigns(): List<QvstCampaign>
 

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/qvst/QvstBreadcrumb.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/qvst/QvstBreadcrumb.kt
@@ -1,0 +1,151 @@
+package com.xpeho.xpeapp.ui.componants.qvst
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.xpeho.xpeapp.ui.viewModel.qvst.QvstBreadcrumbUiState
+import com.xpeho.xpeapp.ui.viewModel.qvst.QvstBreadcrumbViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.xpeho.xpeapp.R
+import com.xpeho.xpeapp.ui.theme.XpeAppTheme
+
+// Stateful composable
+
+@Composable
+fun QvstBreadcrumb(viewModel: QvstBreadcrumbViewModel = viewModel(), modifier: Modifier = Modifier) {
+    val uiState = viewModel.uiState.collectAsState()
+    QvstBreadcrumb(uiState.value, modifier)
+}
+
+// Stateless composable
+
+@Composable
+fun QvstBreadcrumb(uiState: QvstBreadcrumbUiState, modifier: Modifier = Modifier) {
+    Box(modifier = modifier) {
+        when (uiState) {
+            is QvstBreadcrumbUiState.LOADING -> {
+                LoadingQvstBreadcrumb(Modifier.fillMaxWidth())
+            }
+
+            is QvstBreadcrumbUiState.SUCCESS -> {
+                SuccessQvstBreadcrumb(uiState, Modifier.fillMaxWidth())
+            }
+
+            is QvstBreadcrumbUiState.ERROR -> {
+                ErrorQvstBreadcrumb(uiState, Modifier.fillMaxWidth())
+            }
+
+            is QvstBreadcrumbUiState.NO_CURRENT_CAMPAIGN -> {}
+        }
+    }
+}
+
+@Composable
+fun LoadingQvstBreadcrumb(modifier: Modifier = Modifier) {
+    Text(
+        text = stringResource(R.string.chargement),
+        modifier = modifier,
+        textAlign = TextAlign.Center
+    )
+}
+
+@Composable
+fun SuccessQvstBreadcrumb(uiState: QvstBreadcrumbUiState.SUCCESS, modifier: Modifier = Modifier) {
+    val remainingDays = uiState.remainingDays
+    val campaignName = uiState.campaignName
+    val backgroundColor: Color = when (remainingDays) {
+        in 0..7 -> Color.Red
+        in 7..14 -> Color.Yellow
+        else -> MaterialTheme.colorScheme.primary
+    }
+    val textColor: Color = when (remainingDays) {
+        in 0..7 -> Color.Black
+        in 7..14 -> Color.Black
+        else -> MaterialTheme.colorScheme.onPrimary
+    }
+    Text(
+        text = stringResource(R.string.jours_restants, campaignName, remainingDays),
+        modifier = modifier
+            .background(backgroundColor, shape = MaterialTheme.shapes.small)
+            .padding(2.dp),
+        textAlign = TextAlign.Center,
+        color = textColor
+    )
+}
+
+@Composable
+fun ErrorQvstBreadcrumb(uiState: QvstBreadcrumbUiState.ERROR, modifier: Modifier = Modifier) {
+    val errMessage = uiState.message
+    Text(
+        text = stringResource(R.string.erreur_jours_campagne, errMessage),
+        modifier = modifier,
+        textAlign = TextAlign.Center
+    )
+}
+
+// Previews
+
+@Preview
+@Composable
+fun PreviewQvstBreadcrumb10d() {
+    val uiState = QvstBreadcrumbUiState.SUCCESS("Campagne C", 10)
+    XpeAppTheme {
+        QvstBreadcrumb(uiState)
+    }
+}
+
+@Preview
+@Composable
+fun PreviewQvstBreadcrumb5d() {
+    val uiState = QvstBreadcrumbUiState.SUCCESS("Campagne B", 5)
+    XpeAppTheme {
+        QvstBreadcrumb(uiState)
+    }
+}
+
+@Preview
+@Composable
+fun PreviewQvstBreadcrum20d() {
+    val uiState = QvstBreadcrumbUiState.SUCCESS("Campagne A", 20)
+    XpeAppTheme {
+        QvstBreadcrumb(uiState)
+    }
+}
+
+@Preview
+@Composable
+fun PreviewLoadingQvstBreadcrumb() {
+    val uiState = QvstBreadcrumbUiState.LOADING
+    XpeAppTheme {
+        QvstBreadcrumb(uiState)
+    }
+}
+
+@Preview
+@Composable
+fun PreviewErrorQvstBreadcrumb() {
+    val uiState = QvstBreadcrumbUiState.ERROR("API Error")
+    XpeAppTheme {
+        QvstBreadcrumb(uiState)
+    }
+}
+
+@Preview
+@Composable
+fun PreviewNoCurrentCampaignQvstBreadcrumb() {
+    val uiState = QvstBreadcrumbUiState.NO_CURRENT_CAMPAIGN
+    XpeAppTheme {
+        QvstBreadcrumb(uiState)
+    }
+}

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/page/HomePage.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/page/HomePage.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -41,6 +42,7 @@ import com.xpeho.xpeapp.ui.Resources
 import com.xpeho.xpeapp.ui.componants.AppBar
 import com.xpeho.xpeapp.ui.componants.ButtonElevated
 import com.xpeho.xpeapp.ui.componants.Card
+import com.xpeho.xpeapp.ui.componants.qvst.QvstBreadcrumb
 import com.xpeho.xpeapp.ui.theme.SfPro
 import com.xpeho.xpeapp.ui.viewModel.FeatureFlippingComposable
 import com.xpeho.xpeapp.ui.viewModel.FeatureFlippingViewModel
@@ -103,6 +105,11 @@ fun HomePage(
                     }
                 }
             }
+            QvstBreadcrumb(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 22.dp, bottom = 12.dp),
+            )
             FeatureFlippingComposable(
                 featureId = FeatureFlippingEnum.NEWSLETTERS.value,
                 viewModel = featureFlippingViewModel,

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/viewModel/qvst/QvstBreadcrumbViewModel.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/viewModel/qvst/QvstBreadcrumbViewModel.kt
@@ -1,0 +1,70 @@
+package com.xpeho.xpeapp.ui.viewModel.qvst
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.xpeho.xpeapp.data.model.qvst.QvstCampaign
+import com.xpeho.xpeapp.data.service.WordpressAPI
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+
+class QvstBreadcrumbViewModel : ViewModel() {
+    private val _uiState = MutableStateFlow<QvstBreadcrumbUiState>(QvstBreadcrumbUiState.LOADING)
+    val uiState: StateFlow<QvstBreadcrumbUiState> = _uiState
+
+    init {
+        getRemainingTime()
+    }
+
+    private fun getRemainingTime() {
+        viewModelScope.launch {
+            val campaigns = try {
+                WordpressAPI.service.getAllQvstCampaigns()
+            } catch (e: Exception) {
+                _uiState.value = QvstBreadcrumbUiState.ERROR("API Error")
+                return@launch
+            }
+
+            var currentCampaign: QvstCampaign? = campaigns.firstOrNull { _isCurrent(it) }
+
+            if (currentCampaign == null) {
+                _uiState.value = QvstBreadcrumbUiState.NO_CURRENT_CAMPAIGN
+                return@launch
+            }
+
+            _uiState.value = QvstBreadcrumbUiState.SUCCESS(currentCampaign.name, _remainingDays(currentCampaign))
+        }
+
+    }
+
+    private fun _isCurrent(campaign: QvstCampaign): Boolean {
+        val startDateString = campaign.start_date
+        val endDateString = campaign.end_date
+        val currentDate = LocalDate.now()
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        val startDate= LocalDate.parse(startDateString, formatter)
+        val endDate = LocalDate.parse(endDateString, formatter)
+        return currentDate.isAfter(startDate) && currentDate.isBefore(endDate)
+    }
+
+    private fun _remainingDays(campaign: QvstCampaign): Long {
+        val endDate = campaign.end_date
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        val endDateParsed = LocalDate.parse(endDate, formatter)
+        val currentDate = LocalDate.now()
+        return endDateParsed.toEpochDay() - currentDate.toEpochDay() + 1
+    }
+}
+
+sealed class QvstBreadcrumbUiState {
+    object LOADING : QvstBreadcrumbUiState()
+    data class SUCCESS(
+        val campaignName: String,
+        val remainingDays: Long
+    ) : QvstBreadcrumbUiState()
+    object NO_CURRENT_CAMPAIGN : QvstBreadcrumbUiState()
+    data class ERROR(val message: String) : QvstBreadcrumbUiState()
+}

--- a/xpeapp_android/app/src/main/res/values/strings.xml
+++ b/xpeapp_android/app/src/main/res/values/strings.xml
@@ -42,4 +42,7 @@
     <string name="qvst_campaign_detail_theme">Thème : %s</string>
     <string name="qvst_campaign_detail_question">Question : %s</string>
     <string name="qvst_campaign_detail_end_date">Date de fin : %s</string>
+    <string name="chargement">Chargement...</string>
+    <string name="erreur_jours_campagne">Erreur jours campagne : %1$s</string>
+    <string name="jours_restants"><![CDATA[%1$s > %2$s jours restants]]></string>
 </resources>


### PR DESCRIPTION
# Description
Création du breadcrumb des jours restants qvst

# Linked Issues
[What are the issues fixed by this pull request ?](https://github.com/XPEHO/XpeApp/issues/77)

# Changes
What does it change ? Ajout d'un composant QvstBreadcrumb sur la HomePage, qui affiche les jours restants dans la (première) campagne en cours
Is is a breaking change ? Non
Is is a new feature ? Oui
Is is a patch, fix, hotfix ? Non

# Screenshots

![](https://github.com/XPEHO/XpeApp/assets/22717449/3711d2df-1ee4-40cb-a451-6225c76bd9de)

![](https://github.com/XPEHO/XpeApp/assets/22717449/3b1afb87-49df-47a0-8e43-f5eb7c36115f)

![](https://github.com/XPEHO/XpeApp/assets/22717449/22aebcff-f39a-4aa3-af4f-bd4e8c5ddfc1)


# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information

@mmarchal la feature n'est pas terminée à mes yeux, mais je fait la pull request pour que tu puisses la critiquer dès maintenant.

Quelques choses en plus

- Wrap le QvstBreadcrumb dans un FeatureFlippingComposable fait freeze la homepage
- Je vais essayer de le mettre dans une Column en dessous de AppBar

qq chose comme ça, qu'en penses tu ?

```kotlin
Scaffold(
topBar = {
    Column {
        AppBar(
            ...
        ) {
        showDialog.value = true
        }
        QvstBreadcrumb()
    }
}
)
```

