### PR TITLE
feat(QvstBreadcrumb): Add QvstBreadcrumb displaying remaining campaig…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ _Feat_
 - [Issue #7](https://github.com/XPEHO/XpeApp/issues/7) Display notifications whe newsletter is created
 - [Issue #54](https://github.com/XPEHO/XpeApp/issues/56) QVST Campaign feature
 - [Issue #75](https://github.com/XPEHO/XpeApp/pull/75) Add environment variable Firebase 
+- [Issue #77](https://github.com/XPEHO/XpeApp/issues/77) Add QVST remaining days banner
 
 _Fix_
 

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/service/WordpressService.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/service/WordpressService.kt
@@ -42,6 +42,10 @@ interface WordpressService {
     ): String
 
     @Headers("Content-Type: application/json")
+    @GET("xpeho/v1/qvst/campaigns")
+    suspend fun getAllQvstCampaigns(): List<QvstCampaign>
+
+    @Headers("Content-Type: application/json")
     @GET("xpeho/v1/qvst/campaigns:active")
     suspend fun getQvstCampaigns(): List<QvstCampaign>
 

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/qvst/QvstBreadcrumb.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/qvst/QvstBreadcrumb.kt
@@ -54,7 +54,7 @@ fun QvstBreadcrumb(uiState: QvstBreadcrumbUiState, modifier: Modifier = Modifier
 @Composable
 fun LoadingQvstBreadcrumb(modifier: Modifier = Modifier) {
     Text(
-        text = stringResource(R.string.chargement),
+        text = stringResource(R.string.loading),
         modifier = modifier,
         textAlign = TextAlign.Center
     )
@@ -83,7 +83,7 @@ fun SuccessQvstBreadcrumb(uiState: QvstBreadcrumbUiState.SUCCESS, modifier: Modi
     }
 
     Text(
-        text = stringResource(R.string.jours_restants, campaignName, remainingDays.toString()),
+        text = stringResource(R.string.remaining_days_campaign, campaignName, remainingDays.toString()),
         modifier = modifier
             .background(backgroundColor, shape = MaterialTheme.shapes.small)
             .padding(2.dp),
@@ -96,7 +96,7 @@ fun SuccessQvstBreadcrumb(uiState: QvstBreadcrumbUiState.SUCCESS, modifier: Modi
 fun ErrorQvstBreadcrumb(uiState: QvstBreadcrumbUiState.ERROR, modifier: Modifier = Modifier) {
     val errMessage = uiState.message
     Text(
-        text = stringResource(R.string.erreur_jours_campagne, errMessage),
+        text = stringResource(R.string.campaign_days_error, errMessage),
         modifier = modifier,
         textAlign = TextAlign.Center
     )

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/qvst/QvstBreadcrumb.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/qvst/QvstBreadcrumb.kt
@@ -1,0 +1,151 @@
+package com.xpeho.xpeapp.ui.componants.qvst
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.xpeho.xpeapp.ui.viewModel.qvst.QvstBreadcrumbUiState
+import com.xpeho.xpeapp.ui.viewModel.qvst.QvstBreadcrumbViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.xpeho.xpeapp.R
+import com.xpeho.xpeapp.ui.theme.XpeAppTheme
+
+// Stateful composable
+
+@Composable
+fun QvstBreadcrumb(viewModel: QvstBreadcrumbViewModel = viewModel(), modifier: Modifier = Modifier) {
+    val uiState = viewModel.uiState.collectAsState()
+    QvstBreadcrumb(uiState.value, modifier)
+}
+
+// Stateless composable
+
+@Composable
+fun QvstBreadcrumb(uiState: QvstBreadcrumbUiState, modifier: Modifier = Modifier) {
+    Box(modifier = modifier) {
+        when (uiState) {
+            is QvstBreadcrumbUiState.LOADING -> {
+                LoadingQvstBreadcrumb(Modifier.fillMaxWidth())
+            }
+
+            is QvstBreadcrumbUiState.SUCCESS -> {
+                SuccessQvstBreadcrumb(uiState, Modifier.fillMaxWidth())
+            }
+
+            is QvstBreadcrumbUiState.ERROR -> {
+                ErrorQvstBreadcrumb(uiState, Modifier.fillMaxWidth())
+            }
+
+            is QvstBreadcrumbUiState.NO_CURRENT_CAMPAIGN -> {}
+        }
+    }
+}
+
+@Composable
+fun LoadingQvstBreadcrumb(modifier: Modifier = Modifier) {
+    Text(
+        text = stringResource(R.string.chargement),
+        modifier = modifier,
+        textAlign = TextAlign.Center
+    )
+}
+
+@Composable
+fun SuccessQvstBreadcrumb(uiState: QvstBreadcrumbUiState.SUCCESS, modifier: Modifier = Modifier) {
+    val remainingDays = uiState.remainingDays
+    val campaignName = uiState.campaignName
+    val backgroundColor: Color = when (remainingDays) {
+        in 0..7 -> Color.Red
+        in 7..14 -> Color.Yellow
+        else -> MaterialTheme.colorScheme.primary
+    }
+    val textColor: Color = when (remainingDays) {
+        in 0..7 -> Color.Black
+        in 7..14 -> Color.Black
+        else -> MaterialTheme.colorScheme.onPrimary
+    }
+    Text(
+        text = stringResource(R.string.jours_restants, campaignName, remainingDays.toString()),
+        modifier = modifier
+            .background(backgroundColor, shape = MaterialTheme.shapes.small)
+            .padding(2.dp),
+        textAlign = TextAlign.Center,
+        color = textColor
+    )
+}
+
+@Composable
+fun ErrorQvstBreadcrumb(uiState: QvstBreadcrumbUiState.ERROR, modifier: Modifier = Modifier) {
+    val errMessage = uiState.message
+    Text(
+        text = stringResource(R.string.erreur_jours_campagne, errMessage),
+        modifier = modifier,
+        textAlign = TextAlign.Center
+    )
+}
+
+// Previews
+
+@Preview
+@Composable
+fun PreviewQvstBreadcrumb10d() {
+    val uiState = QvstBreadcrumbUiState.SUCCESS("Campagne C", 10)
+    XpeAppTheme {
+        QvstBreadcrumb(uiState)
+    }
+}
+
+@Preview
+@Composable
+fun PreviewQvstBreadcrumb5d() {
+    val uiState = QvstBreadcrumbUiState.SUCCESS("Campagne B", 5)
+    XpeAppTheme {
+        QvstBreadcrumb(uiState)
+    }
+}
+
+@Preview
+@Composable
+fun PreviewQvstBreadcrum20d() {
+    val uiState = QvstBreadcrumbUiState.SUCCESS("Campagne A", 20)
+    XpeAppTheme {
+        QvstBreadcrumb(uiState)
+    }
+}
+
+@Preview
+@Composable
+fun PreviewLoadingQvstBreadcrumb() {
+    val uiState = QvstBreadcrumbUiState.LOADING
+    XpeAppTheme {
+        QvstBreadcrumb(uiState)
+    }
+}
+
+@Preview
+@Composable
+fun PreviewErrorQvstBreadcrumb() {
+    val uiState = QvstBreadcrumbUiState.ERROR("API Error")
+    XpeAppTheme {
+        QvstBreadcrumb(uiState)
+    }
+}
+
+@Preview
+@Composable
+fun PreviewNoCurrentCampaignQvstBreadcrumb() {
+    val uiState = QvstBreadcrumbUiState.NO_CURRENT_CAMPAIGN
+    XpeAppTheme {
+        QvstBreadcrumb(uiState)
+    }
+}

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/qvst/QvstBreadcrumb.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/qvst/QvstBreadcrumb.kt
@@ -60,51 +60,33 @@ fun LoadingQvstBreadcrumb(modifier: Modifier = Modifier) {
     )
 }
 
-private enum class DayRange {
-    UNTIL_7,
-    UNTIL_14,
-    MORE_THAN_14;
-
-    @Composable
-    fun backgroundColor(): Color {
-        return when (this) {
-            UNTIL_7 -> Color.Red
-            UNTIL_14 -> Color.Yellow
-            MORE_THAN_14 -> MaterialTheme.colorScheme.primary
-        }
-    }
-
-    @Composable
-    fun textColor(): Color {
-        return when (this) {
-            UNTIL_7 -> Color.Black
-            UNTIL_14 -> Color.Black
-            MORE_THAN_14 -> MaterialTheme.colorScheme.onPrimary
-        }
-    }
-}
-
-private fun Long.toDayRange(): DayRange {
-    return when {
-        this <= 7 -> DayRange.UNTIL_7
-        this <= 14 -> DayRange.UNTIL_14
-        else -> DayRange.MORE_THAN_14
-    }
+private object RemDaysBounds {
+    const val LOW = 0
+    const val MEDIUM = 7
+    const val HIGH = 14
 }
 
 @Composable
 fun SuccessQvstBreadcrumb(uiState: QvstBreadcrumbUiState.SUCCESS, modifier: Modifier = Modifier) {
     val remainingDays = uiState.remainingDays
     val campaignName = uiState.campaignName
-    val range = remainingDays.toDayRange()
-    val backgroundColor: Color = range.backgroundColor()
-    val textColor: Color = range.textColor()
-    val breadcrumbPadding = 2.dp
+
+    val backgroundColor: Color = when (remainingDays) {
+        in RemDaysBounds.LOW..RemDaysBounds.MEDIUM -> Color.Red
+        in RemDaysBounds.MEDIUM..RemDaysBounds.HIGH -> Color.Yellow
+        else -> MaterialTheme.colorScheme.primary
+    }
+    val textColor: Color = when (remainingDays) {
+        in RemDaysBounds.LOW..RemDaysBounds.MEDIUM -> Color.Black
+        in RemDaysBounds.MEDIUM..RemDaysBounds.HIGH -> Color.Black
+        else -> MaterialTheme.colorScheme.onPrimary
+    }
+
     Text(
         text = stringResource(R.string.jours_restants, campaignName, remainingDays.toString()),
         modifier = modifier
             .background(backgroundColor, shape = MaterialTheme.shapes.small)
-            .padding(breadcrumbPadding),
+            .padding(2.dp),
         textAlign = TextAlign.Center,
         color = textColor
     )
@@ -125,7 +107,8 @@ fun ErrorQvstBreadcrumb(uiState: QvstBreadcrumbUiState.ERROR, modifier: Modifier
 @Preview
 @Composable
 fun PreviewQvstBreadcrumb10d() {
-    val uiState = QvstBreadcrumbUiState.SUCCESS("Campagne C", 10)
+    val days = 10L
+    val uiState = QvstBreadcrumbUiState.SUCCESS("Campagne C", days)
     XpeAppTheme {
         QvstBreadcrumb(uiState)
     }
@@ -134,7 +117,8 @@ fun PreviewQvstBreadcrumb10d() {
 @Preview
 @Composable
 fun PreviewQvstBreadcrumb5d() {
-    val uiState = QvstBreadcrumbUiState.SUCCESS("Campagne B", 5)
+    val days = 5L
+    val uiState = QvstBreadcrumbUiState.SUCCESS("Campagne B", days)
     XpeAppTheme {
         QvstBreadcrumb(uiState)
     }
@@ -143,7 +127,8 @@ fun PreviewQvstBreadcrumb5d() {
 @Preview
 @Composable
 fun PreviewQvstBreadcrum20d() {
-    val uiState = QvstBreadcrumbUiState.SUCCESS("Campagne A", 20)
+    val days = 20L
+    val uiState = QvstBreadcrumbUiState.SUCCESS("Campagne A", days)
     XpeAppTheme {
         QvstBreadcrumb(uiState)
     }

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/qvst/QvstBreadcrumb.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/qvst/QvstBreadcrumb.kt
@@ -60,25 +60,51 @@ fun LoadingQvstBreadcrumb(modifier: Modifier = Modifier) {
     )
 }
 
+private enum class DayRange {
+    UNTIL_7,
+    UNTIL_14,
+    MORE_THAN_14;
+
+    @Composable
+    fun backgroundColor(): Color {
+        return when (this) {
+            UNTIL_7 -> Color.Red
+            UNTIL_14 -> Color.Yellow
+            MORE_THAN_14 -> MaterialTheme.colorScheme.primary
+        }
+    }
+
+    @Composable
+    fun textColor(): Color {
+        return when (this) {
+            UNTIL_7 -> Color.Black
+            UNTIL_14 -> Color.Black
+            MORE_THAN_14 -> MaterialTheme.colorScheme.onPrimary
+        }
+    }
+}
+
+private fun Long.toDayRange(): DayRange {
+    return when {
+        this <= 7 -> DayRange.UNTIL_7
+        this <= 14 -> DayRange.UNTIL_14
+        else -> DayRange.MORE_THAN_14
+    }
+}
+
 @Composable
 fun SuccessQvstBreadcrumb(uiState: QvstBreadcrumbUiState.SUCCESS, modifier: Modifier = Modifier) {
     val remainingDays = uiState.remainingDays
     val campaignName = uiState.campaignName
-    val backgroundColor: Color = when (remainingDays) {
-        in 0..7 -> Color.Red
-        in 7..14 -> Color.Yellow
-        else -> MaterialTheme.colorScheme.primary
-    }
-    val textColor: Color = when (remainingDays) {
-        in 0..7 -> Color.Black
-        in 7..14 -> Color.Black
-        else -> MaterialTheme.colorScheme.onPrimary
-    }
+    val range = remainingDays.toDayRange()
+    val backgroundColor: Color = range.backgroundColor()
+    val textColor: Color = range.textColor()
+    val breadcrumbPadding = 2.dp
     Text(
         text = stringResource(R.string.jours_restants, campaignName, remainingDays.toString()),
         modifier = modifier
             .background(backgroundColor, shape = MaterialTheme.shapes.small)
-            .padding(2.dp),
+            .padding(breadcrumbPadding),
         textAlign = TextAlign.Center,
         color = textColor
     )

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/qvst/QvstBreadcrumb.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/qvst/QvstBreadcrumb.kt
@@ -102,13 +102,30 @@ fun ErrorQvstBreadcrumb(uiState: QvstBreadcrumbUiState.ERROR, modifier: Modifier
     )
 }
 
+private const val CAMPAIGN_C_NAME = "Campagne C"
+private const val CAMPAIGN_C_DAYS = 20L
+
+private const val CAMPAIGN_B_NAME = "Campagne B"
+private const val CAMPAIGN_B_DAYS = 10L
+
+private const val CAMPAIGN_A_NAME = "Campagne A"
+private const val CAMPAIGN_A_DAYS = 5L
+
 // Previews
 
 @Preview
 @Composable
+fun PreviewQvstBreadcrumb20d() {
+    val uiState = QvstBreadcrumbUiState.SUCCESS(CAMPAIGN_C_NAME, CAMPAIGN_C_DAYS)
+    XpeAppTheme {
+        QvstBreadcrumb(uiState)
+    }
+}
+
+@Preview
+@Composable
 fun PreviewQvstBreadcrumb10d() {
-    val days = 10L
-    val uiState = QvstBreadcrumbUiState.SUCCESS("Campagne C", days)
+    val uiState = QvstBreadcrumbUiState.SUCCESS(CAMPAIGN_B_NAME, CAMPAIGN_B_DAYS)
     XpeAppTheme {
         QvstBreadcrumb(uiState)
     }
@@ -116,19 +133,8 @@ fun PreviewQvstBreadcrumb10d() {
 
 @Preview
 @Composable
-fun PreviewQvstBreadcrumb5d() {
-    val days = 5L
-    val uiState = QvstBreadcrumbUiState.SUCCESS("Campagne B", days)
-    XpeAppTheme {
-        QvstBreadcrumb(uiState)
-    }
-}
-
-@Preview
-@Composable
-fun PreviewQvstBreadcrum20d() {
-    val days = 20L
-    val uiState = QvstBreadcrumbUiState.SUCCESS("Campagne A", days)
+fun PreviewQvstBreadcrum5d() {
+    val uiState = QvstBreadcrumbUiState.SUCCESS(CAMPAIGN_A_NAME, CAMPAIGN_A_DAYS)
     XpeAppTheme {
         QvstBreadcrumb(uiState)
     }

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/page/HomePage.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/page/HomePage.kt
@@ -59,43 +59,7 @@ fun HomePage(
 
     Scaffold(
         topBar = {
-            Column {
-                AppBar(
-                    title = stringResource(id = R.string.app_name),
-                    imageVector = Icons.AutoMirrored.Filled.Logout,
-                    actions = {
-                        FeatureFlippingComposable(
-                            featureId = FeatureFlippingEnum.QVST.value,
-                            viewModel = featureFlippingViewModel,
-                            showIfNotEnabled = false,
-                            redirection = {
-                                navigationController.navigate(route = "QVST")
-                            },
-                        ) {
-                            Image(
-                                painter = painterResource(id = R.drawable.qvst),
-                                contentDescription = null,
-                                modifier = Modifier
-                                    .width(80.dp)
-                                    .height(80.dp)
-                                    .padding(16.dp)
-                            )
-                        }
-                    },
-                ) {
-                    showDialog.value = true
-                }
-                FeatureFlippingComposable(
-                    featureId = FeatureFlippingEnum.QVST.value,
-                    viewModel = featureFlippingViewModel,
-                    redirection = {
-                        navigationController.navigate(route = "QVST")
-                    },
-                    showIfNotEnabled = false
-                ) {
-                    QvstBreadcrumb(modifier = Modifier.fillMaxWidth())
-                }
-            }
+            TopBarContent(featureFlippingViewModel, navigationController, showDialog)
         }
     ) {
         Column(
@@ -121,45 +85,98 @@ fun HomePage(
                     }
                 }
             }
-            FeatureFlippingComposable(
-                featureId = FeatureFlippingEnum.NEWSLETTERS.value,
-                viewModel = featureFlippingViewModel,
-                redirection = {
-                    navigationController.navigate(route = "Newsletters")
-                },
-            ) {
-                Card(
-                    imageResource = R.drawable.newsletters,
-                    title = "Newsletters",
-                    color = colorResource(id = R.color.xpeho_color),
-                )
-            }
-            LazyVerticalGrid(
-                verticalArrangement = Arrangement.spacedBy(20.dp),
-                horizontalArrangement = Arrangement.spacedBy(20.dp),
-                contentPadding = PaddingValues(
-                    top = 20.dp,
-                    bottom = 20.dp,
-                ),
-                columns = GridCells.Fixed(2),
-                content = {
-                    items(Resources().listOfMenu.dropWhile { it.idImage == R.drawable.newsletters }) { resource ->
-                        FeatureFlippingComposable(
-                            viewModel = featureFlippingViewModel,
-                            featureId = resource.featureFlippingId.value,
-                            redirection = {
-                                navigationController.navigate(route = resource.redirection)
-                            },
-                        ) {
-                            Card(
-                                imageResource = resource.idImage,
-                                title = resource.title,
-                                color = setColor(resource.idImage),
-                            )
-                        }
-                    }
+            PageGrid(featureFlippingViewModel, navigationController)
+        }
+    }
+}
+
+@Composable
+private fun PageGrid(
+    featureFlippingViewModel: FeatureFlippingViewModel,
+    navigationController: NavController
+) {
+    FeatureFlippingComposable(
+        featureId = FeatureFlippingEnum.NEWSLETTERS.value,
+        viewModel = featureFlippingViewModel,
+        redirection = {
+            navigationController.navigate(route = "Newsletters")
+        },
+    ) {
+        Card(
+            imageResource = R.drawable.newsletters,
+            title = "Newsletters",
+            color = colorResource(id = R.color.xpeho_color),
+        )
+    }
+    LazyVerticalGrid(
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+        horizontalArrangement = Arrangement.spacedBy(20.dp),
+        contentPadding = PaddingValues(
+            top = 20.dp,
+            bottom = 20.dp,
+        ),
+        columns = GridCells.Fixed(2),
+        content = {
+            items(Resources().listOfMenu.dropWhile { it.idImage == R.drawable.newsletters }) { resource ->
+                FeatureFlippingComposable(
+                    viewModel = featureFlippingViewModel,
+                    featureId = resource.featureFlippingId.value,
+                    redirection = {
+                        navigationController.navigate(route = resource.redirection)
+                    },
+                ) {
+                    Card(
+                        imageResource = resource.idImage,
+                        title = resource.title,
+                        color = setColor(resource.idImage),
+                    )
                 }
-            )
+            }
+        }
+    )
+}
+
+@Composable
+private fun TopBarContent(
+    featureFlippingViewModel: FeatureFlippingViewModel,
+    navigationController: NavController,
+    showDialog: MutableState<Boolean>
+) {
+    Column {
+        AppBar(
+            title = stringResource(id = R.string.app_name),
+            imageVector = Icons.AutoMirrored.Filled.Logout,
+            actions = {
+                FeatureFlippingComposable(
+                    featureId = FeatureFlippingEnum.QVST.value,
+                    viewModel = featureFlippingViewModel,
+                    showIfNotEnabled = false,
+                    redirection = {
+                        navigationController.navigate(route = "QVST")
+                    },
+                ) {
+                    Image(
+                        painter = painterResource(id = R.drawable.qvst),
+                        contentDescription = null,
+                        modifier = Modifier
+                            .width(80.dp)
+                            .height(80.dp)
+                            .padding(16.dp)
+                    )
+                }
+            },
+        ) {
+            showDialog.value = true
+        }
+        FeatureFlippingComposable(
+            featureId = FeatureFlippingEnum.QVST.value,
+            viewModel = featureFlippingViewModel,
+            redirection = {
+                navigationController.navigate(route = "QVST")
+            },
+            showIfNotEnabled = false
+        ) {
+            QvstBreadcrumb(modifier = Modifier.fillMaxWidth())
         }
     }
 }

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/page/HomePage.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/page/HomePage.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -41,6 +42,7 @@ import com.xpeho.xpeapp.ui.Resources
 import com.xpeho.xpeapp.ui.componants.AppBar
 import com.xpeho.xpeapp.ui.componants.ButtonElevated
 import com.xpeho.xpeapp.ui.componants.Card
+import com.xpeho.xpeapp.ui.componants.qvst.QvstBreadcrumb
 import com.xpeho.xpeapp.ui.theme.SfPro
 import com.xpeho.xpeapp.ui.viewModel.FeatureFlippingComposable
 import com.xpeho.xpeapp.ui.viewModel.FeatureFlippingViewModel
@@ -57,37 +59,53 @@ fun HomePage(
 
     Scaffold(
         topBar = {
-            AppBar(
-                title = stringResource(id = R.string.app_name),
-                imageVector = Icons.AutoMirrored.Filled.Logout,
-                actions = {
-                    FeatureFlippingComposable(
-                        featureId = FeatureFlippingEnum.QVST.value,
-                        viewModel = featureFlippingViewModel,
-                        showIfNotEnabled = false,
-                        redirection = {
-                            navigationController.navigate(route = "QVST")
-                        },
-                    ) {
-                        Image(
-                            painter = painterResource(id = R.drawable.qvst),
-                            contentDescription = null,
-                            modifier = Modifier
-                                .width(80.dp)
-                                .height(80.dp)
-                                .padding(16.dp)
-                        )
-                    }
-                },
-            ) {
-                showDialog.value = true
+            Column {
+                AppBar(
+                    title = stringResource(id = R.string.app_name),
+                    imageVector = Icons.AutoMirrored.Filled.Logout,
+                    actions = {
+                        FeatureFlippingComposable(
+                            featureId = FeatureFlippingEnum.QVST.value,
+                            viewModel = featureFlippingViewModel,
+                            showIfNotEnabled = false,
+                            redirection = {
+                                navigationController.navigate(route = "QVST")
+                            },
+                        ) {
+                            Image(
+                                painter = painterResource(id = R.drawable.qvst),
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .width(80.dp)
+                                    .height(80.dp)
+                                    .padding(16.dp)
+                            )
+                        }
+                    },
+                ) {
+                    showDialog.value = true
+                }
+                FeatureFlippingComposable(
+                    featureId = FeatureFlippingEnum.QVST.value,
+                    viewModel = featureFlippingViewModel,
+                    redirection = {
+                        navigationController.navigate(route = "QVST")
+                    },
+                    showIfNotEnabled = false
+                ) {
+                    QvstBreadcrumb(modifier = Modifier.fillMaxWidth())
+                }
             }
         }
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(32.dp),
+                .padding(
+                    top = it.calculateTopPadding(),
+                    start = 32.dp,
+                    end = 32.dp,
+                    bottom = 0.dp),
             verticalArrangement = Arrangement.Center,
         ) {
             dialogDisconnection(

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/viewModel/qvst/QvstBreadcrumbViewModel.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/viewModel/qvst/QvstBreadcrumbViewModel.kt
@@ -1,0 +1,70 @@
+package com.xpeho.xpeapp.ui.viewModel.qvst
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.xpeho.xpeapp.data.model.qvst.QvstCampaign
+import com.xpeho.xpeapp.data.service.WordpressAPI
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+
+class QvstBreadcrumbViewModel : ViewModel() {
+    private val _uiState = MutableStateFlow<QvstBreadcrumbUiState>(QvstBreadcrumbUiState.LOADING)
+    val uiState: StateFlow<QvstBreadcrumbUiState> = _uiState
+
+    init {
+        getRemainingTime()
+    }
+
+    private fun getRemainingTime() {
+        viewModelScope.launch {
+            val campaigns = try {
+                WordpressAPI.service.getAllQvstCampaigns()
+            } catch (e: Exception) {
+                _uiState.value = QvstBreadcrumbUiState.ERROR("API Error")
+                return@launch
+            }
+
+            var currentCampaign: QvstCampaign? = campaigns.firstOrNull { _isCurrent(it) }
+
+            if (currentCampaign == null) {
+                _uiState.value = QvstBreadcrumbUiState.NO_CURRENT_CAMPAIGN
+                return@launch
+            }
+
+            _uiState.value = QvstBreadcrumbUiState.SUCCESS(currentCampaign.name, _remainingDays(currentCampaign))
+        }
+
+    }
+
+    private fun _isCurrent(campaign: QvstCampaign): Boolean {
+        val startDateString = campaign.start_date
+        val endDateString = campaign.end_date
+        val currentDate = LocalDate.now()
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        val startDate= LocalDate.parse(startDateString, formatter)
+        val endDate = LocalDate.parse(endDateString, formatter)
+        return currentDate.isAfter(startDate) && currentDate.isBefore(endDate)
+    }
+
+    private fun _remainingDays(campaign: QvstCampaign): Long {
+        val endDate = campaign.end_date
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        val endDateParsed = LocalDate.parse(endDate, formatter)
+        val currentDate = LocalDate.now()
+        return endDateParsed.toEpochDay() - currentDate.toEpochDay() + 1
+    }
+}
+
+sealed class QvstBreadcrumbUiState {
+    object LOADING : QvstBreadcrumbUiState()
+    data class SUCCESS(
+        val campaignName: String,
+        val remainingDays: Long
+    ) : QvstBreadcrumbUiState()
+    object NO_CURRENT_CAMPAIGN : QvstBreadcrumbUiState()
+    data class ERROR(val message: String) : QvstBreadcrumbUiState()
+}

--- a/xpeapp_android/app/src/main/res/values/strings.xml
+++ b/xpeapp_android/app/src/main/res/values/strings.xml
@@ -42,4 +42,7 @@
     <string name="qvst_campaign_detail_theme">Thème : %s</string>
     <string name="qvst_campaign_detail_question">Question : %s</string>
     <string name="qvst_campaign_detail_end_date">Date de fin : %s</string>
+    <string name="chargement">Chargement...</string>
+    <string name="erreur_jours_campagne">Erreur jours campagne : %1$s</string>
+    <string name="jours_restants">%1$s > %2$s jours restants</string>
 </resources>

--- a/xpeapp_android/app/src/main/res/values/strings.xml
+++ b/xpeapp_android/app/src/main/res/values/strings.xml
@@ -42,7 +42,7 @@
     <string name="qvst_campaign_detail_theme">Thème : %s</string>
     <string name="qvst_campaign_detail_question">Question : %s</string>
     <string name="qvst_campaign_detail_end_date">Date de fin : %s</string>
-    <string name="chargement">Chargement...</string>
-    <string name="erreur_jours_campagne">Erreur jours campagne : %1$s</string>
-    <string name="jours_restants">%1$s > %2$s jours restants</string>
+    <string name="loading">Chargement…</string>
+    <string name="campaign_days_error">Erreur jours campagne : %1$s</string>
+    <string name="remaining_days_campaign">%1$s > %2$s jours restants</string>
 </resources>


### PR DESCRIPTION
# Description
Création du breadcrumb des jours restants qvst

# Linked Issues
[What are the issues fixed by this pull request ?](https://github.com/XPEHO/XpeApp/issues/77)

# Changes
What does it change ? Ajout d'un composant QvstBreadcrumb sur la HomePage, qui affiche les jours restants dans la (première) campagne en cours
Is is a breaking change ? Non
Is is a new feature ? Oui
Is is a patch, fix, hotfix ? Non

# Screenshots

![photo_2_2024-03-20_16-49-03](https://github.com/XPEHO/XpeApp/assets/22717449/1291bead-e34d-4c3f-b605-a919e834ab18)
![photo_3_2024-03-20_16-49-03](https://github.com/XPEHO/XpeApp/assets/22717449/d2814b15-ae8f-4269-8422-fa4d8b8a29b2)
![photo_4_2024-03-20_16-49-03](https://github.com/XPEHO/XpeApp/assets/22717449/a531bcd8-3a20-457d-b4a6-f1a6526af113)
![photo_1_2024-03-20_16-49-03](https://github.com/XPEHO/XpeApp/assets/22717449/58afcde9-2431-4d2e-ae5c-22908bd84c94)



# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information

Bug de layout potentiel détecté : 

![photo_2024-03-20_15-39-10](https://github.com/XPEHO/XpeApp/assets/22717449/c256269f-300f-4324-bb4e-687060803daa)


Comment reproduire:
 - Créer un FeatureFlippingComposable avec `showIfNotEnabled = true`
 - Mettre un QvstBreadcrumb dans la lambda `composableAuthorized: @Composable () -> Unit`
 
 le bug arrive qu'on mette ces composants sous la AppBar, ou bien directement dans le `content` du `Scaffold`.
