### PR TITLE
feat(AutoLogin): Auto Login feature through AuthenticationManager singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.1.1
 
+_Feat_
+
+- Skip login screen when user logged in previously
+
 _Fix_
 
 - Update version in build gradle

--- a/xpeapp_android/app/build.gradle
+++ b/xpeapp_android/app/build.gradle
@@ -105,6 +105,7 @@ dependencies {
 
     // Test
     implementation 'com.google.firebase:firebase-firestore-ktx:24.9.1'
+    implementation 'androidx.lifecycle:lifecycle-runtime-compose:2.7.0'
     testImplementation 'junit:junit:4.13.2'
 
     // Android Test

--- a/xpeapp_android/app/src/main/AndroidManifest.xml
+++ b/xpeapp_android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
+        android:name=".XpeApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/MainActivity.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/MainActivity.kt
@@ -13,8 +13,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
 import com.xpeho.xpeapp.ui.Home
 import com.xpeho.xpeapp.ui.theme.XpeAppTheme
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
 
@@ -22,6 +24,10 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         checkPermission()
+        lifecycleScope.launch {
+            // Initialize the authentication manager on Activity creation
+            XpeApp.appModule.authenticationManager.initialize()
+        }
         setContent {
             XpeAppTheme {
                 // A surface container using the 'background' color from the theme

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/XpeApp.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/XpeApp.kt
@@ -1,0 +1,16 @@
+package com.xpeho.xpeapp
+
+import android.app.Application
+import com.xpeho.xpeapp.di.AppModule
+import com.xpeho.xpeapp.di.MainAppModule
+
+class XpeApp: Application() {
+    companion object {
+        lateinit var appModule: AppModule
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        appModule = MainAppModule(appContext = this)
+    }
+}

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/AuthData.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/AuthData.kt
@@ -1,0 +1,8 @@
+package com.xpeho.xpeapp.data
+
+import com.xpeho.xpeapp.data.model.WordpressToken
+
+data class AuthData(
+    val username: String,
+    val token: WordpressToken
+)

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/DatastorePref.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/DatastorePref.kt
@@ -6,7 +6,9 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.google.gson.Gson
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
 class DatastorePref(private val context: Context) {
@@ -15,6 +17,7 @@ class DatastorePref(private val context: Context) {
         private const val PREF_NAME = "XPE_PREF"
         private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = PREF_NAME)
         val CONNECT = stringPreferencesKey("isConnectedLeastOneTime")
+        val AUTH_DATA = stringPreferencesKey("authData")
     }
 
     val isConnectedLeastOneTime: Flow<Boolean> = context.dataStore.data
@@ -38,4 +41,26 @@ class DatastorePref(private val context: Context) {
         .map { preference ->
             preference[stringPreferencesKey("userId")] ?: ""
         }
+
+    // AuthData datastore
+
+    suspend fun setAuthData(authData: AuthData) {
+        val json = Gson().toJson(authData)
+        context.dataStore.edit { preference ->
+            preference[AUTH_DATA] = json
+        }
+    }
+
+    suspend fun getAuthData(): AuthData? {
+        val json = context.dataStore.data.map { preferences ->
+            preferences[AUTH_DATA]
+        }.first()
+        return json?.let { Gson().fromJson(it, AuthData::class.java) }
+    }
+
+    suspend fun clearAuthData() {
+        context.dataStore.edit { preference ->
+            preference.remove(AUTH_DATA)
+        }
+    }
 }

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/service/WordpressRepository.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/service/WordpressRepository.kt
@@ -10,6 +10,10 @@ import java.net.UnknownHostException
 import javax.net.ssl.SSLHandshakeException
 
 class WordpressRepository {
+    companion object {
+        private const val HTTPBADREQUEST = 400
+        private const val HTTPSERVICEUNAVAILABLE = 503
+    }
 
     suspend fun authenticate(credentials: AuthentificationBody): AuthResult<WordpressToken> {
         return try {
@@ -43,7 +47,8 @@ class WordpressRepository {
             Log.e("WordpressRepository", "Network error: ${e.message}")
             return AuthResult.NetworkError
         }
-        if (e is HttpException && e.code() == 400)
+        // Backend sends a 400 Bad Request, should send a 401 Unauthorized
+        if (e is HttpException && e.code() == HTTPBADREQUEST)
             return AuthResult.Unauthorized
         Log.e("WordpressRepository", "Unknown error: ${e.message}")
         throw e
@@ -55,7 +60,7 @@ class WordpressRepository {
             is SocketTimeoutException -> true
             is SSLHandshakeException -> true
             is ConnectException -> true
-            is HttpException -> e.code() == 503
+            is HttpException -> e.code() == HTTPSERVICEUNAVAILABLE
             else -> false
         }
     }

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/service/WordpressRepository.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/service/WordpressRepository.kt
@@ -1,0 +1,68 @@
+package com.xpeho.xpeapp.data.service
+
+import android.util.Log
+import com.xpeho.xpeapp.data.entity.AuthentificationBody
+import com.xpeho.xpeapp.data.model.WordpressToken
+import retrofit2.HttpException
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import javax.net.ssl.SSLHandshakeException
+
+class WordpressRepository {
+
+    suspend fun authenticate(credentials: AuthentificationBody): AuthResult<WordpressToken> {
+        return try {
+            val token = WordpressAPI.service.authentification(credentials)
+            AuthResult.Success(token)
+        } catch (e: Exception) {
+            handleAuthException(e)
+        }
+    }
+
+    suspend fun validateToken(token: WordpressToken): AuthResult<Unit> {
+        return try {
+            WordpressAPI.service.validateToken("Bearer ${token.jwt_token}")
+            AuthResult.Success(Unit)
+        } catch (e: Exception) {
+            handleAuthException(e)
+        }
+    }
+
+    suspend fun getUserId(username: String): String? {
+        return try {
+            WordpressAPI.service.getUserId(username)
+        } catch (e: HttpException) {
+            Log.e("WordpressRepository", "Unknown error: ${e.message}")
+            null
+        }
+    }
+
+    private fun handleAuthException(e: Exception): AuthResult<Nothing> {
+        if (isNetworkError(e)){
+            Log.e("WordpressRepository", "Network error: ${e.message}")
+            return AuthResult.NetworkError
+        }
+        if (e is HttpException && e.code() == 400)
+            return AuthResult.Unauthorized
+        Log.e("WordpressRepository", "Unknown error: ${e.message}")
+        throw e
+    }
+
+    private fun isNetworkError(e: Exception): Boolean {
+        return when (e) {
+            is UnknownHostException -> true
+            is SocketTimeoutException -> true
+            is SSLHandshakeException -> true
+            is ConnectException -> true
+            is HttpException -> e.code() == 503
+            else -> false
+        }
+    }
+}
+
+sealed class AuthResult<out T> {
+    data class Success<out T>(val data: T): AuthResult<T>()
+    object Unauthorized: AuthResult<Nothing>()
+    object NetworkError: AuthResult<Nothing>()
+}

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/service/WordpressService.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/service/WordpressService.kt
@@ -36,6 +36,12 @@ interface WordpressService {
     ): WordpressToken
 
     @Headers("Content-Type: application/json")
+    @GET("api/v1/token-validate")
+    suspend fun validateToken(
+            @Header("Authorization") token: String,
+    )
+
+    @Headers("Content-Type: application/json")
     @GET("xpeho/v1/user")
     suspend fun getUserId(
             @Header("email") username: String,

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/di/AppModule.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/di/AppModule.kt
@@ -1,0 +1,31 @@
+package com.xpeho.xpeapp.di
+
+import android.content.Context
+import com.xpeho.xpeapp.data.DatastorePref
+import com.xpeho.xpeapp.data.service.WordpressRepository
+import com.xpeho.xpeapp.domain.AuthenticationManager
+
+interface AppModule {
+    val authenticationManager: AuthenticationManager
+    val wordpressRepository: WordpressRepository
+    val datastorePref: DatastorePref
+}
+
+class MainAppModule(
+    private val appContext: Context
+) : AppModule {
+    override val authenticationManager: AuthenticationManager by lazy {
+        AuthenticationManager(
+            wordpressRepo = wordpressRepository,
+            datastorePref = datastorePref
+        )
+    }
+
+    override val wordpressRepository: WordpressRepository by lazy {
+        WordpressRepository()
+    }
+
+    override val datastorePref: DatastorePref by lazy {
+        DatastorePref(appContext)
+    }
+}

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/domain/AuthenticationManager.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/domain/AuthenticationManager.kt
@@ -1,0 +1,172 @@
+package com.xpeho.xpeapp.domain
+
+import android.util.Log
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.xpeho.xpeapp.data.AuthData
+import com.xpeho.xpeapp.data.DatastorePref
+import com.xpeho.xpeapp.data.entity.AuthentificationBody
+import com.xpeho.xpeapp.data.model.WordpressToken
+import com.xpeho.xpeapp.data.service.AuthResult
+import com.xpeho.xpeapp.data.service.WordpressRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.tasks.await
+
+/**
+ * Singleton responsible for keeping track of the authentication state,
+ * logging the user in and logging the user out.
+ * @param wordpressRepo: Repository for wordpress authentication
+ * @param datastorePref: Wrapper for the DataStore of Preferences,
+ *  for storing the authentication data
+ */
+class AuthenticationManager(
+    val wordpressRepo: WordpressRepository,
+    val datastorePref: DatastorePref
+) {
+    private val _authState: MutableStateFlow<AuthState> = MutableStateFlow(AuthState.Loading)
+    val authState = _authState.asStateFlow()
+
+    suspend fun initialize() {
+        val authData = datastorePref.getAuthData()
+        if (authData == null) {
+            _authState.value = AuthState.Unauthenticated
+            return
+        }
+        authData.let {
+            val loginRes = login(it)
+            if (loginRes is LoginResult.Success) {
+                _authState.value = AuthState.Authenticated(it)
+            } else {
+                _authState.value = AuthState.Unauthenticated
+            }
+        }
+    }
+
+    suspend fun login(username: String, password: String): LoginResult<Unit> {
+        val wordpressToken = when(val res = loginWordpress(username, password)) {
+            LoginResult.NetworkError -> return LoginResult.NetworkError
+            LoginResult.Unauthorized -> return LoginResult.Unauthorized
+            is LoginResult.Success -> res.data
+        }
+
+        when(loginFirebase(username)) {
+            LoginResult.NetworkError -> return LoginResult.NetworkError
+            LoginResult.Unauthorized -> return LoginResult.Unauthorized
+            is LoginResult.Success -> {}
+        }
+
+        val authData = AuthData(username, wordpressToken)
+        val wordpressUid = wordpressRepo.getUserId(username)
+        writeAuthentication(authData, wordpressUid)
+        _authState.value = AuthState.Authenticated(authData)
+        return LoginResult.Success(Unit)
+    }
+
+    private suspend fun login(authData: AuthData): LoginResult<Unit> {
+        val wpLoginResult = loginWordpress(authData)
+        when(wpLoginResult) {
+            LoginResult.NetworkError -> return LoginResult.NetworkError
+            LoginResult.Unauthorized -> return LoginResult.Unauthorized
+            is LoginResult.Success -> {}
+        }
+
+        when(loginFirebase(authData.username)) {
+            LoginResult.NetworkError -> return LoginResult.NetworkError
+            LoginResult.Unauthorized -> return LoginResult.Unauthorized
+            is LoginResult.Success -> {}
+        }
+
+        val wordpressUid = wordpressRepo.getUserId(authData.username)
+        writeAuthentication(authData, wordpressUid)
+        _authState.value = AuthState.Authenticated(authData)
+        return LoginResult.Success(Unit)
+    }
+
+    private suspend fun writeAuthentication(authData: AuthData, wordpressUid: String?) {
+        datastorePref.setAuthData(authData)
+        datastorePref.setIsConnectedLeastOneTime(true)
+        wordpressUid?.let{ datastorePref.setUserId(it) }
+    }
+
+    suspend fun logout() {
+        FirebaseAuth.getInstance().signOut()
+        datastorePref.clearAuthData()
+        _authState.value = AuthState.Unauthenticated
+    }
+
+    private suspend fun loginWordpress(username: String, password: String): LoginResult<WordpressToken> {
+        val wpAuthRes = wordpressRepo.authenticate(
+            AuthentificationBody(username, password)
+        )
+        return when(wpAuthRes) {
+            AuthResult.NetworkError -> {
+                _authState.value = AuthState.Unauthenticated
+                Log.e("AuthenticationManager", "Network error authenticating with wordpress")
+                return LoginResult.NetworkError
+            }
+            AuthResult.Unauthorized -> {
+                _authState.value = AuthState.Unauthenticated
+                Log.i("AuthenticationManager", "User Unauthorized")
+                return LoginResult.Unauthorized
+            }
+            is AuthResult.Success -> LoginResult.Success(wpAuthRes.data)
+        }
+    }
+
+    private suspend fun loginWordpress(authData: AuthData): LoginResult<Unit> {
+        val wpAuthRes = wordpressRepo.validateToken(authData.token)
+        return when(wpAuthRes) {
+            AuthResult.NetworkError -> {
+                _authState.value = AuthState.Unauthenticated
+                Log.e("AuthenticationManager", "Network error validating token with wordpress")
+                return LoginResult.NetworkError
+            }
+            AuthResult.Unauthorized -> {
+                _authState.value = AuthState.Unauthenticated
+                Log.i("AuthenticationManager", "User Unauthorized")
+                return LoginResult.Unauthorized
+            }
+            is AuthResult.Success -> LoginResult.Success(Unit)
+        }
+    }
+
+    private suspend fun loginFirebase(username: String): LoginResult<Unit> {
+        try {
+            FirebaseAuth.getInstance().signInAnonymously().await()
+        } catch(e: Exception) {
+            _authState.value = AuthState.Unauthenticated
+            Log.e("AuthenticationManager", "Error signing in to firebase", e)
+            return LoginResult.NetworkError
+        }
+
+        if (!usernameInFirestoreWordpressUsers(username)){
+            _authState.value = AuthState.Unauthenticated
+            Log.i("AuthenticationManager", "User not in firestore")
+            return LoginResult.Unauthorized
+        }
+
+        return LoginResult.Success(Unit)
+    }
+
+    private suspend fun usernameInFirestoreWordpressUsers(username: String): Boolean {
+        val firestore = FirebaseFirestore.getInstance()
+        val users = firestore.collection("wordpressUsers")
+            .get()
+            .await()
+        return users.documents
+            .any { user -> user["email"] == username }
+    }
+}
+
+sealed class LoginResult<out T> {
+    object NetworkError : LoginResult<Nothing>()
+    object Unauthorized : LoginResult<Nothing>()
+    data class Success<out T>(val data: T): LoginResult<T>()
+}
+
+sealed class AuthState {
+    object Loading: AuthState()
+    object Unauthenticated: AuthState()
+    data class Authenticated(val authData: AuthData): AuthState()
+}

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/Home.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/Home.kt
@@ -2,17 +2,13 @@ package com.xpeho.xpeapp.ui
 
 import android.util.Log
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import com.google.firebase.messaging.FirebaseMessaging
 import com.xpeho.xpeapp.enums.Screens
-import com.xpeho.xpeapp.ui.viewModel.FeatureFlippingViewModel
 
 @Composable
-fun Home(
-    viewModel: FeatureFlippingViewModel = viewModel(),
-) {
+fun Home() {
     FirebaseMessaging.getInstance().subscribeToTopic("newsletter")
     FirebaseMessaging.getInstance()
         .token.addOnCompleteListener { task ->
@@ -29,6 +25,6 @@ fun Home(
         navController = navigationController,
         startDestination = Screens.Login.name,
     ) {
-        navigationBuilder(navigationController, viewModel)
+        navigationBuilder(navigationController)
     }
 }

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/Navigation.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/Navigation.kt
@@ -12,23 +12,28 @@ import com.xpeho.xpeapp.ui.page.newsletter.NewsletterPage
 import com.xpeho.xpeapp.ui.page.newsletter.detail.NewsletterDetailPage
 import com.xpeho.xpeapp.ui.page.qvst.QvstCampaignDetailPage
 import com.xpeho.xpeapp.ui.page.qvst.QvstPage
-import com.xpeho.xpeapp.ui.viewModel.FeatureFlippingViewModel
 
 fun NavGraphBuilder.navigationBuilder(
     navigationController: NavHostController,
-    viewModel: FeatureFlippingViewModel
 ) {
     composable(route = Screens.Login.name) {
         LoginPage(
-            featureFlippingViewModel = viewModel,
-        ) {
-            navigationController.navigate(route = Screens.Home.name)
-        }
+            onLoginSuccess = {
+                navigationController.navigate(route = Screens.Home.name) {
+                    popUpTo(Screens.Login.name) { inclusive = true }
+                }
+            }
+        )
     }
     composable(route = Screens.Home.name) {
         HomePage(
             navigationController = navigationController,
-            featureFlippingViewModel = viewModel,
+            onDisconnectPressed = {
+                // Return to login page and clear the backstack
+                navigationController.navigate(route = Screens.Login.name) {
+                    popUpTo(Screens.Home.name) { inclusive = true }
+                }
+            }
         )
     }
     composable(route = Screens.Newsletters.name) {

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/page/HomePage.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/page/HomePage.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
@@ -35,8 +36,8 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.xpeho.xpeapp.R
+import com.xpeho.xpeapp.XpeApp
 import com.xpeho.xpeapp.data.FeatureFlippingEnum
-import com.xpeho.xpeapp.enums.Screens
 import com.xpeho.xpeapp.ui.Resources
 import com.xpeho.xpeapp.ui.componants.AppBar
 import com.xpeho.xpeapp.ui.componants.ButtonElevated
@@ -44,15 +45,15 @@ import com.xpeho.xpeapp.ui.componants.Card
 import com.xpeho.xpeapp.ui.theme.SfPro
 import com.xpeho.xpeapp.ui.viewModel.FeatureFlippingComposable
 import com.xpeho.xpeapp.ui.viewModel.FeatureFlippingViewModel
-import com.xpeho.xpeapp.ui.viewModel.WordpressViewModel
+import kotlinx.coroutines.launch
 
 @Composable
 @Suppress("UnusedMaterial3ScaffoldPaddingParameter")
 fun HomePage(
-    vm: WordpressViewModel = viewModel(),
+    onDisconnectPressed : () -> Unit,
     navigationController: NavController,
-    featureFlippingViewModel: FeatureFlippingViewModel,
 ) {
+    val featureFlippingViewModel = viewModel<FeatureFlippingViewModel>()
     val showDialog = remember { mutableStateOf(false) }
 
     Scaffold(
@@ -90,17 +91,13 @@ fun HomePage(
                 .padding(32.dp),
             verticalArrangement = Arrangement.Center,
         ) {
+            val coroutineScope = rememberCoroutineScope()
             dialogDisconnection(
                 showDialog,
             ) {
-                vm.logout()
-                // Return to login page and clear the backstack
-                navigationController.navigate(
-                    route = Screens.Login.name,
-                ) {
-                    popUpTo(Screens.Login.name) {
-                        inclusive = true
-                    }
+                coroutineScope.launch {
+                    XpeApp.appModule.authenticationManager.logout()
+                    onDisconnectPressed()
                 }
             }
             FeatureFlippingComposable(

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/uiState/WordpressUiState.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/uiState/WordpressUiState.kt
@@ -1,10 +1,8 @@
 package com.xpeho.xpeapp.ui.uiState
 
-import com.xpeho.xpeapp.data.model.WordpressToken
-
 interface WordpressUiState {
     object EMPTY : WordpressUiState
     object LOADING : WordpressUiState
     data class ERROR(val error: String) : WordpressUiState
-    data class SUCCESS(val token: WordpressToken) : WordpressUiState
+    object SUCCESS : WordpressUiState
 }

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/viewModel/ViewModelFactoryHelper.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/viewModel/ViewModelFactoryHelper.kt
@@ -1,0 +1,20 @@
+package com.xpeho.xpeapp.ui.viewModel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+/**
+ * Helper function to create a ViewModelProvider.Factory that creates a ViewModel using the provided initializer.
+ */
+inline fun <reified VM: ViewModel> viewModelFactory(crossinline initializer: () -> VM): ViewModelProvider.Factory {
+    return object : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if(modelClass.isAssignableFrom(VM::class.java)){
+                @Suppress("UNCHECKED_CAST")
+                return initializer() as T
+            } else {
+                throw IllegalArgumentException("ViewModelFactory can only create instances of ${VM::class.java}")
+            }
+        }
+    }
+}

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/viewModel/WordpressViewModel.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/viewModel/WordpressViewModel.kt
@@ -1,122 +1,52 @@
 package com.xpeho.xpeapp.ui.viewModel
 
-import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.firestore.FirebaseFirestore
-import com.xpeho.xpeapp.data.DatastorePref
 import com.xpeho.xpeapp.data.entity.AuthentificationBody
-import com.xpeho.xpeapp.data.model.WordpressToken
-import com.xpeho.xpeapp.data.service.WordpressAPI
+import com.xpeho.xpeapp.domain.AuthenticationManager
+import com.xpeho.xpeapp.domain.LoginResult
 import com.xpeho.xpeapp.ui.uiState.WordpressUiState
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
-import retrofit2.HttpException
-import java.io.IOException
 
-class WordpressViewModel : ViewModel() {
+class WordpressViewModel(
+    var authManager: AuthenticationManager
+) : ViewModel() {
 
     var body: AuthentificationBody? by mutableStateOf(null)
-
     var wordpressState: WordpressUiState by mutableStateOf(WordpressUiState.EMPTY)
-    var token: WordpressToken? by mutableStateOf(null)
 
-    fun onLogin(datastorePref: DatastorePref, featureFlippingViewModel: FeatureFlippingViewModel) {
+    fun onLogin() {
         viewModelScope.launch {
-            body?.let { authent ->
-                // Show loader
-                wordpressState = WordpressUiState.LOADING
-
-                try {
-                    // Connect to Wordpress API
-                    val result = WordpressAPI.service.authentification(authent)
-                    token = result
-
-                    // Connect to Firebase
-                    FirebaseAuth.getInstance().signInAnonymously().await()
-
-                    // Check if the user is authorized
-                    if (checkUserAuthorization(authent.username)) {
-                        Log.d("WordpressViewModel", "Firebase connected")
-                        // Save the connected boolean in Datastore
-                        viewModelScope.launch { datastorePref.setIsConnectedLeastOneTime(true) }
-
-                        // Get the user id from database
-                        val userId = WordpressAPI.service.getUserId(authent.username)
-
-                        // Save the user id in Datastore
-                        viewModelScope.launch { datastorePref.setUserId(userId) }
-
-                        // Load feature flipping
-                        featureFlippingViewModel.getFeatureFlipping()
-                        wordpressState = if (featureFlippingViewModel.uiState is FeatureFlippingUiState.SUCCESS) {
-                            WordpressUiState.SUCCESS(token = result)
-                        } else {
-                            Log.e("WordpressViewModel", featureFlippingViewModel.uiState.toString())
-                            WordpressUiState.ERROR(
-                                error = "Oups, il y a eu un problème dans le chargement des fonctionnalités"
-                            )
-                        }
-                    } else {
-                        wordpressState = WordpressUiState.ERROR(
-                            error = "Vous n'avez pas les droits pour accéder à cette page"
-                        )
-                    }
-                } catch (httpException: HttpException) {
-                    wordpressState = WordpressUiState.ERROR(
-                        error = getErrorMessage(
-                            error = httpException.code().toString()
-                        )
-                    )
-                } catch (ioException: IOException) {
-                    wordpressState = WordpressUiState.ERROR(
-                        error = ioException.message ?: "Une erreur est survenue ! Veuillez réessayer."
-                    )
-                }
+            body?.let {
+                handleOnLogin(credentials = it)
             }
         }
-        println("WordpressViewModel : $wordpressState")
     }
 
-    private suspend fun checkUserAuthorization(username: String): Boolean {
-        val isAuthorized = mutableStateOf(false)
-
-        val db = FirebaseFirestore.getInstance()
-
-        val users = db.collection("wordpressUsers")
-            .get()
-            .await()
-
-        for (user in users.documents) {
-            if (user["email"] == username) {
-                isAuthorized.value = true
-                break
-            } else {
-                isAuthorized.value = false
-            }
+    private suspend fun handleOnLogin(
+        credentials: AuthentificationBody
+    ) {
+        wordpressState = WordpressUiState.LOADING
+        val loginResult = authManager.login(credentials.username, credentials.password)
+        wordpressState = when(loginResult) {
+            LoginResult.NetworkError -> WordpressUiState.ERROR(NETWORK_ERROR_STRING)
+            LoginResult.Unauthorized -> WordpressUiState.ERROR(UNAUTHORIZED_ERROR_STRING)
+            is LoginResult.Success -> WordpressUiState.SUCCESS
         }
-
-        return isAuthorized.value
     }
 
     fun logout() {
-        token = null
-        FirebaseAuth.getInstance().signOut()
-        wordpressState = WordpressUiState.EMPTY
+        viewModelScope.launch {
+            authManager.logout()
+            wordpressState = WordpressUiState.EMPTY
+        }
     }
 
-    private fun getErrorMessage(error: String?): String {
-        val errorReturn = mutableStateOf("Une erreur est survenue ! Veuillez réessayer.")
-        when (error) {
-            "400" -> errorReturn.value = "Identifiants incorrects"
-            "403" -> errorReturn.value = "Vous n'avez pas les droits pour accéder à cette page"
-            "404" -> errorReturn.value = "Page introuvable"
-            "500" -> errorReturn.value = "Une erreur est survenue ! Veuillez réessayer."
-        }
-        return errorReturn.value
+    companion object {
+        private const val NETWORK_ERROR_STRING = "Erreur de réseau"
+        private const val UNAUTHORIZED_ERROR_STRING = "Identifiants incorrects"
     }
 }


### PR DESCRIPTION
# Description

Add AutoLogin functionality to the LoginPage() by introducing a AuthenticationManager singleton scoped to the App's lifecycle.
Set up manual dependency injection in `com.xpeho.xpeapp.di`

# Linked Issues

https://github.com/XPEHO/XpeApp/issues/51

# Changes

## What does it change ? 

- LoginPage
- MainActivity
- Home
- Navigation
- HomePage
- FeatureFlippingViewModel

## Is is a breaking change ?

In some sense yes

## Is is a new feature ?

Yes, auto login

## Is is a patch, fix, hotfix ?

No

# Screenshots

![Loading Screen](https://github.com/XPEHO/XpeApp/assets/22717449/3511202f-d8db-471f-876c-6bbfcd571076)

# Tests

How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information

- I'm worried that my solution is too complex for what was achieved. Please give your opinion about the complexity.- 
- There is a bug caused by the navigation animation, or the lack of buttonPressed state for back buttons: on the newsletter screen, pressing the graphical back button twice will trigger navigationController.navigateUp() twice and pop a page that is supposed to be unpoppable (HomePage).