### PR TITLE
fix(HandleMultipeOnTapBack): Fixed bug where the onTapBack Lambda was…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 _Fix_
 
 - Update version in build gradle
+- [Issue #86](https://github.com/XPEHO/XpeApp/issues/86) Fix multiple back button presses
 
 _Chore_
 

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/AppBar.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/AppBar.kt
@@ -11,19 +11,20 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import com.xpeho.xpeapp.R
-import com.xpeho.xpeapp.data.FeatureFlippingEnum
 import com.xpeho.xpeapp.ui.theme.SfPro
-import com.xpeho.xpeapp.ui.viewModel.FeatureFlippingComposable
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -33,6 +34,7 @@ fun AppBar(
     actions:  @Composable() (RowScope.() -> Unit)? = null,
     onTapBack: () -> Unit,
 ) {
+    var isBackTapped by remember { mutableStateOf(false) }
     CenterAlignedTopAppBar(
         modifier = Modifier
             .fillMaxWidth(),
@@ -46,7 +48,11 @@ fun AppBar(
             )
         },
         navigationIcon = {
-            IconButton(onClick = onTapBack) {
+            IconButton(onClick = {
+                if (!isBackTapped)
+                    onTapBack()
+                isBackTapped = true
+            }) {
                 Icon(
                     imageVector = imageVector ?: Icons.AutoMirrored.Filled.ArrowBack,
                     contentDescription = null


### PR DESCRIPTION
… called more than once per AppBar

# Description

The AppBar component allows the user to trigger the call to onTapBack multiple times, thus making it possible to call navigationController.navigateUp() multiple times

# Linked Issues
https://github.com/XPEHO/XpeApp/issues/86

# Changes
What does it change ? AppBar behavior: it can now only be clicked once
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ? yes

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
