### PR TITLE
fix(FeatureFlippingLoadingOob): Fix a bug where feature flipping over…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _Fix_
 
 - Update version in build gradle
 - [Issue #86](https://github.com/XPEHO/XpeApp/issues/86) Fix multiple back button presses
+- [Issue #85](https://github.com/XPEHO/XpeApp/issues/85) Fix Feature Flipping overlay going out of bounds
 
 _Chore_
 


### PR DESCRIPTION
Fix a bug where feature flipping overlays took up the whole page

# Description
UI Bug on error/loading path where feature flipping overlays took up the whole page because of `Modifier.fillMaxSize()`

# Linked Issues
https://github.com/XPEHO/XpeApp/issues/85

# Changes
~What does it change ?~
~Is is a breaking change ?~
~Is is a new feature ?~
Is is a patch, fix, hotfix ? **Yes** 

# Screenshots

![FfFixSuccessCase](https://github.com/XPEHO/XpeApp/assets/22717449/e94f5460-c5f9-450f-9db2-edc0d3720661)

![FfFixLoadingCase](https://github.com/XPEHO/XpeApp/assets/22717449/cb73edf3-2dd2-44d0-be63-1c4ad17de10e)

![FfFixErrorCase](https://github.com/XPEHO/XpeApp/assets/22717449/c0037e9d-4922-45d2-a468-13651b461acf)


# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
This is still not ideal as the overlay shape doesn't necessarily match the content shape. Idealy, the `composableAuthorized: @Composable () -> Unit` should handle the overlay, for example in this way `composableAuthorized: @Composable (overlay: @Composable (modifier: Modifier) -> Unit) -> Unit`