### PR TITLE
chore(WordpressApiTokenSend): Send Bearer Token when user is authenticated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _Fix_
 _Chore_
 
 - Update changelog
+- [Issue #83](https://github.com/XPEHO/XpeApp/issues/83) Add authorization header to WordpressAPI requests
 
 ## 1.1.0
 

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/service/WordpressService.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/service/WordpressService.kt
@@ -2,11 +2,13 @@ package com.xpeho.xpeapp.data.service
 
 import com.google.gson.GsonBuilder
 import com.xpeho.xpeapp.BuildConfig
+import com.xpeho.xpeapp.XpeApp
 import com.xpeho.xpeapp.data.entity.AuthentificationBody
 import com.xpeho.xpeapp.data.entity.QvstAnswerBody
 import com.xpeho.xpeapp.data.model.WordpressToken
 import com.xpeho.xpeapp.data.model.qvst.QvstCampaign
 import com.xpeho.xpeapp.data.model.qvst.QvstQuestion
+import com.xpeho.xpeapp.data.service.interceptor.AuthorizationHeaderInterceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -18,8 +20,13 @@ private const val BASE_URL = BuildConfig.BACKEND_URL
 private val gson = GsonBuilder().setLenient().create()
 
 val logging = HttpLoggingInterceptor().apply { level = HttpLoggingInterceptor.Level.BODY }
+val authorization = AuthorizationHeaderInterceptor(XpeApp.appModule.authenticationManager)
 
-private val okHttpClient = OkHttpClient.Builder().addInterceptor(logging).build()
+private val okHttpClient = OkHttpClient
+    .Builder()
+    .addInterceptor(authorization)
+    .addInterceptor(logging)
+    .build()
 
 private val retrofit =
         Retrofit.Builder()


### PR DESCRIPTION
Send Autorization Bearer Token in WordpressAPI request headers when the user is authenticated.

# Description

This commit adds an authorization header to requests made to the WordpressAPI. It introduces a new `AuthorizationHeaderInterceptor` interceptor that dynamically adds a bearer token to outgoing requests based on the authentication state obtained from the `AuthenticationManager`. Additionally, it updates the `WordpressService.kt` to incorporate this interceptor into the OkHttpClient instance. This enhancement addresses Issue #83, ensuring proper authentication for WordpressAPI requests.

# Linked Issues

Closes #83 

# Changes

WordpressService.kt:

Created a new autorization Interceptor instance, passing XpeApp.appModule.authenticationManager.
Updated okHttpClient to include the authorization interceptor.
This ensures that the authorization header is added to outgoing requests to the WordpressAPI.

AuthorizationHeaderInterceptor.kt:

Created a new Kotlin file to define the AuthorizationHeaderInterceptor class.
Implemented Interceptor interface for intercepting outgoing requests.
Added logic to retrieve the authentication state from AuthenticationManager.
Based on the authentication state, the interceptor either adds the bearer token to the request header or proceeds without it.

# Screenshots
~Put screenshots (if any)~

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information

If we want to change the behavior of the WordpressAPI through the app, we could create a builder object that changes the interceptors of the OkHttp client
