### PR TITLE
fix(bearerTokenCrash): Fix bug where 2 bearer token are sent, crashing the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ _Fix_
 - Update version in build gradle
 - [Issue #86](https://github.com/XPEHO/XpeApp/issues/86) Fix multiple back button presses
 - [Issue #85](https://github.com/XPEHO/XpeApp/issues/85) Fix Feature Flipping overlay going out of bounds
+- [Issue #93](https://github.com/XPEHO/XpeApp/issues/93) Fix bug where 2 bearer token are sent, crashing the app
 
 _Chore_
 

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/service/interceptor/AuthorizationHeaderInterceptor.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/service/interceptor/AuthorizationHeaderInterceptor.kt
@@ -11,6 +11,10 @@ class AuthorizationHeaderInterceptor(
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val authState = authenticationManager.authState.value
+        val hasAuthorizationHeader = chain.request().headers("Authorization").isNotEmpty()
+        if (hasAuthorizationHeader) {
+            return identityResponse(chain)
+        }
         return when(authState) {
             AuthState.Loading -> identityResponse(chain)
             AuthState.Unauthenticated -> identityResponse(chain)
@@ -20,7 +24,7 @@ class AuthorizationHeaderInterceptor(
     }
 
     private fun authorizedResponse(chain: Interceptor.Chain, token: String): Response {
-        Log.i("AuthorizationHeaderInterceptor", "Request was sent with bearer token $token")
+        Log.i("AuthorizationHeaderInterceptor", "Request was sent with the added bearer token $token")
         val request = chain.request().newBuilder()
             .addHeader("Authorization", token)
             .build()
@@ -28,7 +32,7 @@ class AuthorizationHeaderInterceptor(
     }
 
     private fun identityResponse(chain: Interceptor.Chain): Response {
-        Log.i("AuthorizationHeaderInterceptor", "Request was sent witout a bearer token")
+        Log.i("AuthorizationHeaderInterceptor", "Request was sent witout an added bearer token")
         return chain.proceed(chain.request())
     }
 }


### PR DESCRIPTION
# Description

Fixes a bug where two bearer tokens were sent after configuration changes, thus crashing the app.

# Linked Issues

Closes #93

# Changes

Fix, prevents sending two bearer tokens

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other
