### PR TITLE
fix(campaignDaysIncluded): Include start and end days in the _isCurrent campaign check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ _Fix_
 - Update version in build gradle
 - [Issue #86](https://github.com/XPEHO/XpeApp/issues/86) Fix multiple back button presses
 - [Issue #85](https://github.com/XPEHO/XpeApp/issues/85) Fix Feature Flipping overlay going out of bounds
+- Include start and end day in qvstBreadcrumb `_isCurrent` check
 
 _Chore_
 

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/viewModel/qvst/QvstBreadcrumbViewModel.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/viewModel/qvst/QvstBreadcrumbViewModel.kt
@@ -1,5 +1,6 @@
 package com.xpeho.xpeapp.ui.viewModel.qvst
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.xpeho.xpeapp.data.model.qvst.QvstCampaign
@@ -30,12 +31,22 @@ class QvstBreadcrumbViewModel : ViewModel() {
 
             var currentCampaign: QvstCampaign? = campaigns.firstOrNull { _isCurrent(it) }
 
+            for (campaign in campaigns) {
+                if(_isCurrent(campaign)) {
+                    currentCampaign = campaign
+                    break
+                }
+            }
+
+            Log.d("breadcrumb", "currentCampaign: $currentCampaign")
+
             if (currentCampaign == null) {
                 _uiState.value = QvstBreadcrumbUiState.NO_CURRENT_CAMPAIGN
                 return@launch
             }
 
-            _uiState.value = QvstBreadcrumbUiState.SUCCESS(currentCampaign.name, _remainingDays(currentCampaign))
+            _uiState.value = QvstBreadcrumbUiState.SUCCESS(currentCampaign.name,
+                _remainingDays(currentCampaign))
         }
 
     }
@@ -47,7 +58,8 @@ class QvstBreadcrumbViewModel : ViewModel() {
         val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
         val startDate= LocalDate.parse(startDateString, formatter)
         val endDate = LocalDate.parse(endDateString, formatter)
-        return currentDate.isAfter(startDate) && currentDate.isBefore(endDate)
+        return (currentDate.isAfter(startDate) && currentDate.isBefore(endDate))
+                || currentDate.isEqual(startDate) || currentDate.isEqual(endDate)
     }
 
     private fun _remainingDays(campaign: QvstCampaign): Long {


### PR DESCRIPTION
# Description
Include start and end days in condition to display the qvst campaign banner

# Changes

Fix

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other
