### PR TITLE
feat(imprAutoLoginPerf): Make auth non blocking and UI pretty while loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 _Feat_
 
-- Skip login screen when user logged in previously
+- [Issue #98](https://github.com/XPEHO/XpeApp/issues/98) Skip login screen when user logged in previously, gracefully display UI before login is complete
 - [Issue #99](https://github.com/XPEHO/XpeApp/issues/99) Enabled Hardware Acceleration
 
 _Fix_

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/AuthData.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/AuthData.kt
@@ -1,8 +1,0 @@
-package com.xpeho.xpeapp.data
-
-import com.xpeho.xpeapp.data.model.WordpressToken
-
-data class AuthData(
-    val username: String,
-    val token: WordpressToken
-)

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/DatastorePref.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/DatastorePref.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.google.gson.Gson
+import com.xpeho.xpeapp.domain.AuthData
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -18,6 +19,7 @@ class DatastorePref(private val context: Context) {
         private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = PREF_NAME)
         val CONNECT = stringPreferencesKey("isConnectedLeastOneTime")
         val AUTH_DATA = stringPreferencesKey("authData")
+        val WAS_CONNECTED_LAST_TIME = stringPreferencesKey("wasConnectedLastTime")
     }
 
     val isConnectedLeastOneTime: Flow<Boolean> = context.dataStore.data
@@ -63,4 +65,19 @@ class DatastorePref(private val context: Context) {
             preference.remove(AUTH_DATA)
         }
     }
+
+    // wasConnectedLastTime datastore
+
+    suspend fun setWasConnectedLastTime(wasConnected: Boolean) {
+        context.dataStore.edit { preference ->
+            preference[WAS_CONNECTED_LAST_TIME] = wasConnected.toString()
+        }
+    }
+
+    suspend fun getWasConnectedLastTime(): Boolean {
+        return context.dataStore.data.map { preferences ->
+            preferences[WAS_CONNECTED_LAST_TIME]?.toBoolean() ?: false
+        }.first()
+    }
 }
+

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/model/FeatureFlipping.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/model/FeatureFlipping.kt
@@ -10,14 +10,6 @@ data class FeatureFlipping(
     val prodEnabled: Boolean,
 )
 
-fun emptyFeatureFlipping() = FeatureFlipping(
-    id = "",
-    name = "",
-    description = "",
-    uatEnabled = false,
-    prodEnabled = false,
-)
-
 fun DocumentSnapshot?.toFeatureFlipping(): FeatureFlipping {
     return FeatureFlipping(
         id = this?.id ?: "",

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/service/WordpressRepository.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/service/WordpressRepository.kt
@@ -66,8 +66,8 @@ class WordpressRepository {
     }
 }
 
-sealed class AuthResult<out T> {
-    data class Success<out T>(val data: T): AuthResult<T>()
-    object Unauthorized: AuthResult<Nothing>()
-    object NetworkError: AuthResult<Nothing>()
+sealed interface AuthResult<out T> {
+    object Unauthorized: AuthResult<Nothing>
+    object NetworkError: AuthResult<Nothing>
+    data class Success<out T>(val data: T): AuthResult<T>
 }

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/service/interceptor/AuthorizationHeaderInterceptor.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/service/interceptor/AuthorizationHeaderInterceptor.kt
@@ -16,8 +16,7 @@ class AuthorizationHeaderInterceptor(
             return identityResponse(chain)
         }
         return when(authState) {
-            AuthState.Loading -> identityResponse(chain)
-            AuthState.Unauthenticated -> identityResponse(chain)
+            is AuthState.Unauthenticated -> identityResponse(chain)
             is AuthState.Authenticated ->
                 authorizedResponse(chain, "Bearer ${authState.authData.token.jwt_token}")
         }

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/domain/AuthenticationManager.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/domain/AuthenticationManager.kt
@@ -1,16 +1,17 @@
 package com.xpeho.xpeapp.domain
 
-import android.util.Log
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
-import com.xpeho.xpeapp.data.AuthData
 import com.xpeho.xpeapp.data.DatastorePref
 import com.xpeho.xpeapp.data.entity.AuthentificationBody
 import com.xpeho.xpeapp.data.model.WordpressToken
 import com.xpeho.xpeapp.data.service.AuthResult
 import com.xpeho.xpeapp.data.service.WordpressRepository
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.tasks.await
 
 /**
@@ -24,129 +25,73 @@ class AuthenticationManager(
     val wordpressRepo: WordpressRepository,
     val datastorePref: DatastorePref
 ) {
-    private val _authState: MutableStateFlow<AuthState> = MutableStateFlow(AuthState.Loading)
+    private val _authState: MutableStateFlow<AuthState> = MutableStateFlow(AuthState.Unauthenticated)
     val authState = _authState.asStateFlow()
 
-    suspend fun initialize() {
-        val authData = datastorePref.getAuthData()
-        if (authData == null) {
-            _authState.value = AuthState.Unauthenticated
-            return
-        }
-        authData.let {
-            val loginRes = login(it)
-            if (loginRes is LoginResult.Success) {
-                _authState.value = AuthState.Authenticated(it)
-            } else {
-                _authState.value = AuthState.Unauthenticated
+    fun restoreAuthStateFromStorage() = runBlocking {
+         datastorePref.getAuthData()?.let {
+            _authState.value = AuthState.Authenticated(it)
+         }
+    }
+
+    suspend fun isAuthValid(): Boolean {
+        return when(val authState = this.authState.value) {
+            is AuthState.Unauthenticated -> false
+            is AuthState.Authenticated -> {
+                // Note(loucas): Order of operations here is important,
+                // lazy `&&` evalutation makes this faster
+                FirebaseAuth.getInstance().currentUser != null
+                    && wordpressRepo.validateToken(authState.authData.token) is AuthResult.Success
+                    && usernameInFirestoreWordpressUsers(authState.authData.username)
             }
         }
     }
 
-    suspend fun login(username: String, password: String): LoginResult<Unit> {
-        val wordpressToken = when(val res = loginWordpress(username, password)) {
-            LoginResult.NetworkError -> return LoginResult.NetworkError
-            LoginResult.Unauthorized -> return LoginResult.Unauthorized
-            is LoginResult.Success -> res.data
+    suspend fun login(username: String, password: String): AuthResult<WordpressToken> = coroutineScope {
+        val wpDefRes = async {
+            wordpressRepo.authenticate(AuthentificationBody(username, password))
+        }
+        val fbDefRes = async {
+            try {
+                FirebaseAuth.getInstance().signInAnonymously().await()
+            } catch (e: Exception) {
+                return@async AuthResult.NetworkError
+            }
+            if(!usernameInFirestoreWordpressUsers(username)){
+                return@async AuthResult.Unauthorized
+            } else {
+                return@async AuthResult.Success(Unit)
+            }
         }
 
-        when(loginFirebase(username)) {
-            LoginResult.NetworkError -> return LoginResult.NetworkError
-            LoginResult.Unauthorized -> return LoginResult.Unauthorized
-            is LoginResult.Success -> {}
+        val wpRes = wpDefRes.await()
+        val fbRes = fbDefRes.await()
+        if(wpRes is AuthResult.NetworkError || fbRes is AuthResult.NetworkError) {
+            return@coroutineScope AuthResult.NetworkError
+        }
+        if(wpRes is AuthResult.Unauthorized || fbRes is AuthResult.Unauthorized) {
+            return@coroutineScope AuthResult.Unauthorized
         }
 
-        val authData = AuthData(username, wordpressToken)
-        val wordpressUid = wordpressRepo.getUserId(username)
-        writeAuthentication(authData, wordpressUid)
+        val authData = AuthData(username, (wpRes as AuthResult.Success).data)
+        writeAuthentication(authData)
         _authState.value = AuthState.Authenticated(authData)
-        return LoginResult.Success(Unit)
+        return@coroutineScope wpRes
     }
 
-    private suspend fun login(authData: AuthData): LoginResult<Unit> {
-        val wpLoginResult = loginWordpress(authData)
-        when(wpLoginResult) {
-            LoginResult.NetworkError -> return LoginResult.NetworkError
-            LoginResult.Unauthorized -> return LoginResult.Unauthorized
-            is LoginResult.Success -> {}
-        }
-
-        when(loginFirebase(authData.username)) {
-            LoginResult.NetworkError -> return LoginResult.NetworkError
-            LoginResult.Unauthorized -> return LoginResult.Unauthorized
-            is LoginResult.Success -> {}
-        }
-
+    private suspend fun writeAuthentication(authData: AuthData) {
         val wordpressUid = wordpressRepo.getUserId(authData.username)
-        writeAuthentication(authData, wordpressUid)
-        _authState.value = AuthState.Authenticated(authData)
-        return LoginResult.Success(Unit)
-    }
-
-    private suspend fun writeAuthentication(authData: AuthData, wordpressUid: String?) {
         datastorePref.setAuthData(authData)
         datastorePref.setIsConnectedLeastOneTime(true)
+        datastorePref.setWasConnectedLastTime(true)
         wordpressUid?.let{ datastorePref.setUserId(it) }
     }
 
     suspend fun logout() {
         FirebaseAuth.getInstance().signOut()
         datastorePref.clearAuthData()
+        datastorePref.setWasConnectedLastTime(false)
         _authState.value = AuthState.Unauthenticated
-    }
-
-    private suspend fun loginWordpress(username: String, password: String): LoginResult<WordpressToken> {
-        val wpAuthRes = wordpressRepo.authenticate(
-            AuthentificationBody(username, password)
-        )
-        return when(wpAuthRes) {
-            AuthResult.NetworkError -> {
-                _authState.value = AuthState.Unauthenticated
-                Log.e("AuthenticationManager", "Network error authenticating with wordpress")
-                return LoginResult.NetworkError
-            }
-            AuthResult.Unauthorized -> {
-                _authState.value = AuthState.Unauthenticated
-                Log.i("AuthenticationManager", "User Unauthorized")
-                return LoginResult.Unauthorized
-            }
-            is AuthResult.Success -> LoginResult.Success(wpAuthRes.data)
-        }
-    }
-
-    private suspend fun loginWordpress(authData: AuthData): LoginResult<Unit> {
-        val wpAuthRes = wordpressRepo.validateToken(authData.token)
-        return when(wpAuthRes) {
-            AuthResult.NetworkError -> {
-                _authState.value = AuthState.Unauthenticated
-                Log.e("AuthenticationManager", "Network error validating token with wordpress")
-                return LoginResult.NetworkError
-            }
-            AuthResult.Unauthorized -> {
-                _authState.value = AuthState.Unauthenticated
-                Log.i("AuthenticationManager", "User Unauthorized")
-                return LoginResult.Unauthorized
-            }
-            is AuthResult.Success -> LoginResult.Success(Unit)
-        }
-    }
-
-    private suspend fun loginFirebase(username: String): LoginResult<Unit> {
-        try {
-            FirebaseAuth.getInstance().signInAnonymously().await()
-        } catch(e: Exception) {
-            _authState.value = AuthState.Unauthenticated
-            Log.e("AuthenticationManager", "Error signing in to firebase", e)
-            return LoginResult.NetworkError
-        }
-
-        if (!usernameInFirestoreWordpressUsers(username)){
-            _authState.value = AuthState.Unauthenticated
-            Log.i("AuthenticationManager", "User not in firestore")
-            return LoginResult.Unauthorized
-        }
-
-        return LoginResult.Success(Unit)
     }
 
     private suspend fun usernameInFirestoreWordpressUsers(username: String): Boolean {
@@ -159,14 +104,9 @@ class AuthenticationManager(
     }
 }
 
-sealed class LoginResult<out T> {
-    object NetworkError : LoginResult<Nothing>()
-    object Unauthorized : LoginResult<Nothing>()
-    data class Success<out T>(val data: T): LoginResult<T>()
+sealed interface AuthState {
+    object Unauthenticated: AuthState
+    data class Authenticated(val authData: AuthData): AuthState
 }
 
-sealed class AuthState {
-    object Loading: AuthState()
-    object Unauthenticated: AuthState()
-    data class Authenticated(val authData: AuthData): AuthState()
-}
+data class AuthData(val username: String, val token: WordpressToken)

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/Home.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/Home.kt
@@ -8,7 +8,7 @@ import com.google.firebase.messaging.FirebaseMessaging
 import com.xpeho.xpeapp.enums.Screens
 
 @Composable
-fun Home() {
+fun Home(startScreen: Screens) {
     FirebaseMessaging.getInstance().subscribeToTopic("newsletter")
     FirebaseMessaging.getInstance()
         .token.addOnCompleteListener { task ->
@@ -23,7 +23,7 @@ fun Home() {
 
     NavHost(
         navController = navigationController,
-        startDestination = Screens.Login.name,
+        startDestination = startScreen.name,
     ) {
         navigationBuilder(navigationController)
     }

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/Navigation.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/Navigation.kt
@@ -3,6 +3,7 @@ package com.xpeho.xpeapp.ui
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import com.xpeho.xpeapp.XpeApp
 import com.xpeho.xpeapp.enums.Screens
 import com.xpeho.xpeapp.ui.page.ColleaguePage
 import com.xpeho.xpeapp.ui.page.HomePage
@@ -12,6 +13,9 @@ import com.xpeho.xpeapp.ui.page.newsletter.NewsletterPage
 import com.xpeho.xpeapp.ui.page.newsletter.detail.NewsletterDetailPage
 import com.xpeho.xpeapp.ui.page.qvst.QvstCampaignDetailPage
 import com.xpeho.xpeapp.ui.page.qvst.QvstPage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 fun NavGraphBuilder.navigationBuilder(
     navigationController: NavHostController,
@@ -29,6 +33,9 @@ fun NavGraphBuilder.navigationBuilder(
         HomePage(
             navigationController = navigationController,
             onDisconnectPressed = {
+                CoroutineScope(Dispatchers.IO).launch {
+                    XpeApp.appModule.authenticationManager.logout()
+                }
                 // Return to login page and clear the backstack
                 navigationController.navigate(route = Screens.Login.name) {
                     popUpTo(Screens.Home.name) { inclusive = true }

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/Card.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/Card.kt
@@ -31,12 +31,13 @@ import com.xpeho.xpeapp.ui.theme.SfPro
 
 @Composable
 fun Card(
+    modifier: Modifier = Modifier,
     imageResource: Int,
     title: String,
     color: Color?,
 ) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .clip(
                 shape = RoundedCornerShape(16.dp),
             )

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/modifier/GreyScaleModifier.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/modifier/GreyScaleModifier.kt
@@ -1,0 +1,39 @@
+package com.xpeho.xpeapp.ui.modifier
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ColorMatrix
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.platform.InspectorInfo
+
+data class GreyScaleModifier(val saturation: Float): ModifierNodeElement<GreyScaleModifierNode>() {
+    override fun create(): GreyScaleModifierNode = GreyScaleModifierNode(saturation)
+    override fun update(node: GreyScaleModifierNode) {
+        node.saturation = saturation
+    }
+    override fun InspectorInfo.inspectableProperties() {
+        properties["saturation"] = saturation
+    }
+}
+
+class GreyScaleModifierNode(var saturation: Float) : DrawModifierNode, Modifier.Node() {
+    override fun ContentDrawScope.draw() {
+        val saturationMatrix = ColorMatrix().apply { setToSaturation(saturation) }
+        val saturationFilter = ColorFilter.colorMatrix(saturationMatrix)
+        val paint = Paint().apply {
+            colorFilter = saturationFilter
+        }
+        drawIntoCanvas {
+            it.saveLayer(Rect(0f, 0f, size.width, size.height), paint)
+            drawContent()
+            it.restore()
+        }
+    }
+}
+
+fun Modifier.greyScale(saturation: Float) = this then GreyScaleModifier(saturation)

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/page/LoginPage.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/page/LoginPage.kt
@@ -7,10 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
@@ -24,12 +21,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.xpeho.xpeapp.R
 import com.xpeho.xpeapp.XpeApp
 import com.xpeho.xpeapp.data.entity.AuthentificationBody
-import com.xpeho.xpeapp.domain.AuthState
 import com.xpeho.xpeapp.enums.InputTextFieldKeyboardType
 import com.xpeho.xpeapp.ui.componants.ButtonElevated
 import com.xpeho.xpeapp.ui.componants.CustomDialog
@@ -39,46 +34,11 @@ import com.xpeho.xpeapp.ui.viewModel.WordpressViewModel
 import com.xpeho.xpeapp.ui.viewModel.viewModelFactory
 
 /**
- * Login page with loading animation for saved authentication
- * @param onLoginSuccess: Callback when login is successful
- */
-@Composable
-fun LoginPage(onLoginSuccess: () -> Unit) {
-    val authState = XpeApp.appModule.authenticationManager.authState.collectAsStateWithLifecycle().value
-    // If auth state switches to Authenticated, notify of login success
-    LaunchedEffect(authState) {
-        if (authState is AuthState.Authenticated) {
-            onLoginSuccess()
-        }
-    }
-    when(authState) {
-        is AuthState.Unauthenticated -> LoginPageForm(onLoginSuccess)
-        is AuthState.Loading -> Loading()
-        is AuthState.Authenticated -> {}
-    }
-}
-
-/**
- * Full screen loading icon
- */
-@Composable
-private fun Loading() {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .fillMaxHeight(),
-        contentAlignment = Alignment.Center
-    ) {
-        CircularProgressIndicator()
-    }
-}
-
-/**
  * Login page
  * @param onLoginSuccess: Callback when login is successful
  */
 @Composable
-private fun LoginPageForm(onLoginSuccess: () -> Unit) {
+fun LoginPage(onLoginSuccess: () -> Unit) {
     val wordpressViewModel = viewModel<WordpressViewModel>(
         factory = viewModelFactory {
             WordpressViewModel(XpeApp.appModule.authenticationManager)

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/viewModel/FeatureFlippingUiState.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/viewModel/FeatureFlippingUiState.kt
@@ -1,10 +1,9 @@
 package com.xpeho.xpeapp.ui.viewModel
 
-import com.xpeho.xpeapp.data.model.FeatureFlipping
+import com.xpeho.xpeapp.data.FeatureFlippingEnum
 
 interface FeatureFlippingUiState {
-
     object LOADING : FeatureFlippingUiState
     data class ERROR(val error: String) : FeatureFlippingUiState
-    data class SUCCESS(val featureFlipping: List<FeatureFlipping>) : FeatureFlippingUiState
+    data class SUCCESS(val featureEnabled: Map<FeatureFlippingEnum, Boolean>) : FeatureFlippingUiState
 }

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/viewModel/WordpressViewModel.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/viewModel/WordpressViewModel.kt
@@ -6,13 +6,13 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.xpeho.xpeapp.data.entity.AuthentificationBody
+import com.xpeho.xpeapp.data.service.AuthResult
 import com.xpeho.xpeapp.domain.AuthenticationManager
-import com.xpeho.xpeapp.domain.LoginResult
 import com.xpeho.xpeapp.ui.uiState.WordpressUiState
 import kotlinx.coroutines.launch
 
 class WordpressViewModel(
-    var authManager: AuthenticationManager
+    private var authManager: AuthenticationManager
 ) : ViewModel() {
 
     var body: AuthentificationBody? by mutableStateOf(null)
@@ -32,16 +32,9 @@ class WordpressViewModel(
         wordpressState = WordpressUiState.LOADING
         val loginResult = authManager.login(credentials.username, credentials.password)
         wordpressState = when(loginResult) {
-            LoginResult.NetworkError -> WordpressUiState.ERROR(NETWORK_ERROR_STRING)
-            LoginResult.Unauthorized -> WordpressUiState.ERROR(UNAUTHORIZED_ERROR_STRING)
-            is LoginResult.Success -> WordpressUiState.SUCCESS
-        }
-    }
-
-    fun logout() {
-        viewModelScope.launch {
-            authManager.logout()
-            wordpressState = WordpressUiState.EMPTY
+            AuthResult.NetworkError -> WordpressUiState.ERROR(NETWORK_ERROR_STRING)
+            AuthResult.Unauthorized -> WordpressUiState.ERROR(UNAUTHORIZED_ERROR_STRING)
+            is AuthResult.Success -> WordpressUiState.SUCCESS
         }
     }
 


### PR DESCRIPTION
Make auth non blocking and UI pretty while loading

# Description

- Skips to HomePage if user was connected last time
- Checks auth status in the background, kicks user to Login screen if invalid
- Changes UI to appear functional even when loading, and gracefully transitions

# Linked Issues
Closes #98 

# Changes

Simplifies the AuthenticationManager, makes authentication non blocking.
Changes the FeatureFlippingViewModel and HomePage UI to gracefully display a before-login home page.

This is a breaking change, and a new feature

# Tests

- [x] Manually

