### PR TITLE
fix(flashingQvstCampaignList): Prevents excessive redraw, adds spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _Fix_
 - [Issue #85](https://github.com/XPEHO/XpeApp/issues/85) Fix Feature Flipping overlay going out of bounds
 - Include start and end day in qvstBreadcrumb `_isCurrent` check
 - [Issue #93](https://github.com/XPEHO/XpeApp/issues/93) Fix bug where 2 bearer token are sent, crashing the app
+- [Issue #96](https://github.com/XPEHO/XpeApp/issues/96) Fix bug where QVST Campaigns list was flashing because of a refetch on redraws
 
 _Chore_
 

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/qvst/QvstCampaignList.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/qvst/QvstCampaignList.kt
@@ -44,6 +44,7 @@ fun QvstCampaignList(
             ) {
                 onCampaignClick(campaigns[index])
             }
+            Spacer(modifier = Modifier.height(16.dp))
         }
     }
 }

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/page/qvst/QvstPage.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/page/qvst/QvstPage.kt
@@ -29,7 +29,6 @@ fun QvstPage(
     navigationController: NavController,
     onBackPressed: () -> Unit,
 ) {
-    campaignViewModel.getActiveCampaign()
     Scaffold(
         topBar = {
             AppBar(

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/viewModel/qvst/QvstCampaignViewModel.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/viewModel/qvst/QvstCampaignViewModel.kt
@@ -13,7 +13,11 @@ class QvstCampaignViewModel : ViewModel() {
 
     var state: QvstUiState by mutableStateOf(QvstUiState.EMPTY)
 
-    fun getActiveCampaign() {
+    init {
+        getActiveCampaign()
+    }
+
+    private fun getActiveCampaign() {
         state = QvstUiState.LOADING
         viewModelScope.launch {
             state = try {


### PR DESCRIPTION
Prevents excessive redraw, adds spacing

- Pulls the campaign fetching to viewModel initialization time, thus prevening calling getActiveCampaign() on every redraw of QvstPage
- Add spacing between QvstCampaignList items

# Linked Issues
Closes #96 

# Changes
This is a patch that changes the spacing of the QVST Campaigns list, and prevents re-fetching of the data on every redraw, which caused flashing

# Tests
How has it been tested ?

- [x] With hopes and dreams
