### PR TITLE
fix(showNotificationCrash): Fix crash on some andr. versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ _Fix_
 - Include start and end day in qvstBreadcrumb `_isCurrent` check
 - [Issue #93](https://github.com/XPEHO/XpeApp/issues/93) Fix bug where 2 bearer token are sent, crashing the app
 - [Issue #96](https://github.com/XPEHO/XpeApp/issues/96) Fix bug where QVST Campaigns list was flashing because of a refetch on redraws
+- [Issue #95](https://github.com/XPEHO/XpeApp/issues/95) Fix bug where app crashed upon calling showNotification on devices of API 31 or above
 
 _Chore_
 

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/service/MyFirebaseMessagingService.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/data/service/MyFirebaseMessagingService.kt
@@ -1,6 +1,7 @@
 package com.xpeho.xpeapp.data.service
 
 import android.util.Log
+import android.widget.Toast
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.xpeho.xpeapp.data.DatastorePref
@@ -26,10 +27,16 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
                     context = context
                 ).isConnectedLeastOneTime
                 if (isConnected.first()) {
-                    NewsletterNotification().showNotification(
-                        context = context,
-                        content = it.body.toString(),
-                    )
+                    try {
+                        NewsletterNotification().showNotification(
+                            context = context,
+                            content = it.body.toString(),
+                        )
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Error while showing notification", e)
+                        Toast.makeText(context, "Error while showing notification: ${e.message}",
+                            Toast.LENGTH_LONG).show()
+                    }
                 }
             }
         }

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/NewsletterNotification.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/NewsletterNotification.kt
@@ -34,7 +34,10 @@ class NewsletterNotification {
             context,
             0,
             intent,
-            PendingIntent.FLAG_UPDATE_CURRENT,
+            // Note(loucas): Not using FLAG_IMMUTABLE causes a crash on Android 12 and above
+            // see: https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability
+            // see: https://github.com/XPEHO/XpeApp/issues/95
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
         val notification = Notification.Builder(


### PR DESCRIPTION
Fixes a crash on devices with Android API >= 31 by adding FLAG_IMMUTABLE to notification click intent  

# Linked Issues
Closes #95 

# Changes
Hotfix

# Tests

Tested Manually by calling showNotification in onCreate