### PR TITLE
chore(appBundleCI): Add github workflows for release and debug appbundle

### DIFF
--- a/.github/workflows/debugAppBundle.yaml
+++ b/.github/workflows/debugAppBundle.yaml
@@ -1,0 +1,45 @@
+name: Build debug appbundle
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  releaseAppBundle:
+    name: Build debug appbundle
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: xpeapp_android
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Create firebase config file
+        run: |
+          echo "${{ secrets.GOOGLE_SERVICE_FILE }}" | base64 -d > app/google-services.json
+          if [ -n "${{ secrets.UAT_CONFIG_FILE }}" ]; then
+            mkdir -p app/config
+            echo "${{ secrets.UAT_CONFIG_FILE }}" | base64 -d > app/config/uat.properties
+          fi
+         
+      - name: Grant execute permission for gradlew and build
+        run: |
+          chmod +x ./gradlew
+          ./gradlew bundleDebug
+
+      - name: Upload appbundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-bundle
+          path: "xpeapp_android/app/build/outputs/bundle/debug/app-debug.aab"
+

--- a/.github/workflows/releaseAppBundle.yaml
+++ b/.github/workflows/releaseAppBundle.yaml
@@ -1,0 +1,50 @@
+name: Build release appbundle
+
+on: 
+  push:
+    branches:
+      - main
+
+jobs:
+  releaseAppBundle:
+    name: Build release bundle
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: xpeapp_android
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Create firebase config file
+        run: |
+          echo "${{ secrets.GOOGLE_SERVICE_FILE }}" | base64 -d > app/google-services.json
+          if [ -n "${{ secrets.PROD_CONFIG_FILE }}" ]; then
+            mkdir -p app/config
+            echo "${{ secrets.PROD_CONFIG_FILE }}" | base64 -d > app/config/prod.properties
+          fi
+
+      - name: Create key.properties file
+        run: |
+          echo "${{ secrets.KEY_PROPERTIES }}" | base64 -d > key.properties
+
+      - name: Create keystore file
+        run: |
+          echo "${{ secrets.KEYSTORE }}" | base64 -d > app/keystore.jks
+         
+      - name: Grant execute permission for gradlew and build
+        run: |
+          chmod +x ./gradlew
+          ./gradlew bundleRelease
+
+      - name: Upload release bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-bundle
+          path: "xpeapp_android/app/build/outputs/bundle/release/app-release.aab"
+          

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ _Chore_
 
 - Update changelog
 - [Issue #83](https://github.com/XPEHO/XpeApp/issues/83) Add authorization header to WordpressAPI requests
+- [Issue #78](https://github.com/XPEHO/XpeApp/issues/78) Create CI pipelines to automate release builds
 
 ## 1.1.0
 


### PR DESCRIPTION
Attention, le workflow ne fonctionnera pas avec une simple PR, il faut aussi update les secrets:

- secrets.PROD_CONFIG_FILE : Actuellement, il faut que çe soit le base64 du fichier `uat.properties`, mais avec ENVIRONEMENT="prod"
- secrets.KEY_PROPERTIES : Le base64 du fichier `key.properties`, mais avec `storeFile=keystore.jks`
- secrets.KEYSTORE : le fichier `upload-xpeho-bundle.jks`

# Linked Issues

Progresses #78 

# Changes
Adds two build pipelines to create

1. A debug app bundle
2. A signed release app bundle

