### PR TITLE
feat(darkModeSupport): Readable dark theme app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ _Feat_
 - [Issue #98](https://github.com/XPEHO/XpeApp/issues/98) Skip login screen when user logged in previously, gracefully display UI before login is complete
 - [Issue #99](https://github.com/XPEHO/XpeApp/issues/99) Enabled Hardware Acceleration
 - [Issue #97](https://github.com/XPEHO/XpeApp/issues/97) Shortened navigation animations
+- [Issue #108](https://github.com/XPEHO/XpeApp/issues/108) Make the app's dark theme readable
 
 _Fix_
 

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/Card.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/Card.kt
@@ -2,6 +2,7 @@ package com.xpeho.xpeapp.ui.componants
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,6 +11,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -41,7 +43,9 @@ fun Card(
             .clip(
                 shape = RoundedCornerShape(16.dp),
             )
-            .background(Color.White)
+            .background(
+                if (isSystemInDarkTheme()) MaterialTheme.colorScheme.surfaceVariant else Color.White
+            )
             .shadow(
                 elevation = 5.dp,
                 spotColor = Color.Transparent,
@@ -71,6 +75,7 @@ fun Card(
                 fontFamily = SfPro,
                 textAlign = TextAlign.Center,
                 fontStyle = FontStyle.Italic,
+                color = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier
                     .padding(
                         top = 16.dp,

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/colleague/HappyBirthdayComponent.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/colleague/HappyBirthdayComponent.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Cake
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -60,7 +61,7 @@ fun HappyBirthdayComponent(
             modifier = Modifier
                 .padding(start = 5.dp)
                 .width(200.dp),
-            color = Color.Black,
+            color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center,
             maxLines = 2,
             style = TextStyle(

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/newsletter/NewsletterCard.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/newsletter/NewsletterCard.kt
@@ -1,6 +1,7 @@
 package com.xpeho.xpeapp.ui.componants.newsletter
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
@@ -10,6 +11,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowForwardIos
 import androidx.compose.material.icons.filled.Newspaper
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -34,7 +36,8 @@ fun NewsletterCard(newsletter: Newsletter) {
             .height(60.dp)
             .padding(10.dp)
             .background(
-                color = Color.White,
+                color = if (isSystemInDarkTheme())
+                    MaterialTheme.colorScheme.surfaceVariant else Color.White,
                 shape = RoundedCornerShape(50.dp)
             )
     ) {
@@ -58,6 +61,7 @@ fun NewsletterCard(newsletter: Newsletter) {
             ),
             fontFamily = SfPro,
             fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface
         )
         Spacer(
             modifier = Modifier.weight(1f)

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/qvst/QvstCampaignList.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/qvst/QvstCampaignList.kt
@@ -3,16 +3,19 @@ package com.xpeho.xpeapp.ui.componants.qvst
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowRight
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -60,7 +63,8 @@ fun QvstCampaignItem(
         modifier = Modifier
             .fillMaxWidth()
             .background(
-                color = androidx.compose.ui.graphics.Color.White,
+                color = if (isSystemInDarkTheme())
+                    MaterialTheme.colorScheme.surfaceVariant else Color.White,
                 shape = androidx.compose.foundation.shape.RoundedCornerShape(20.dp)
             )
             .padding(16.dp)
@@ -81,6 +85,7 @@ fun QvstCampaignItem(
                     style = TextStyle(
                         fontWeight = FontWeight.Bold,
                         fontSize = 15.sp,
+                        color = MaterialTheme.colorScheme.onSurface
                     )
                 )
                 Box(modifier = Modifier.height(8.dp))
@@ -92,6 +97,7 @@ fun QvstCampaignItem(
                     style = TextStyle(
                         fontWeight = FontWeight.Bold,
                         fontSize = 12.sp,
+                        color = MaterialTheme.colorScheme.onSurface
                     )
                 )
             }
@@ -103,6 +109,7 @@ fun QvstCampaignItem(
                 style = TextStyle(
                     fontWeight = FontWeight.Bold,
                     fontSize = 12.sp,
+                    color = MaterialTheme.colorScheme.onSurface
                 )
             )
             Image(

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/vacation/MyRequestLeaveItem.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/componants/vacation/MyRequestLeaveItem.kt
@@ -1,12 +1,14 @@
 package com.xpeho.xpeapp.ui.componants.vacation
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -32,7 +34,8 @@ fun MyRequestLeaveItem(requestLeave: RequestLeaveDetail) {
         modifier = Modifier
             .fillMaxWidth()
             .clip(shape = RoundedCornerShape(50.dp))
-            .background(color = Color.White)
+            .background(color = if(isSystemInDarkTheme()) MaterialTheme.colorScheme.surfaceVariant
+            else Color.White)
             .padding(
                 top = 12.dp,
                 bottom = 12.dp,
@@ -43,7 +46,7 @@ fun MyRequestLeaveItem(requestLeave: RequestLeaveDetail) {
             text = getTitleWithType(requestLeave.type),
             fontWeight = FontWeight.Bold,
             style = TextStyle(
-                color = Color.Black,
+                color = MaterialTheme.colorScheme.onSurface,
                 fontSize = 14.sp,
             )
         )
@@ -60,7 +63,7 @@ fun MyRequestLeaveItem(requestLeave: RequestLeaveDetail) {
                     )
                 }",
                 style = TextStyle(
-                    color = Color.Black,
+                    color = MaterialTheme.colorScheme.onSurface,
                     fontSize = 16.sp,
                 )
             )

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/page/VacationPage.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/page/VacationPage.kt
@@ -1,5 +1,6 @@
 package com.xpeho.xpeapp.ui.page
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,6 +10,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -31,7 +33,8 @@ fun VacationPage(
 ) {
     val vacationRequestLeave = Resources().request
     Scaffold(
-        containerColor = colorResource(id = R.color.xpeho_background_color),
+        containerColor = if(isSystemInDarkTheme()) MaterialTheme.colorScheme.surface
+            else colorResource(id = R.color.xpeho_background_color),
         topBar = {
             AppBar(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
@@ -43,7 +46,8 @@ fun VacationPage(
         floatingActionButton = {
             FloatingActionButton(
                 onClick = {},
-                containerColor = Color.White,
+                containerColor = if(isSystemInDarkTheme()) MaterialTheme.colorScheme.primary
+                    else Color.White,
             ) {
                 Icon(
                     Icons.Filled.Add,

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/page/newsletter/detail/NewsletterDetailComponent.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/page/newsletter/detail/NewsletterDetailComponent.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -60,12 +61,13 @@ fun NewsletterDetailComponent(newsletter: Newsletter) {
                 fontFamily = SfPro,
                 fontStyle = FontStyle.Italic,
                 fontSize = 24.sp,
+                color = MaterialTheme.colorScheme.onSurface
             )
         }
         Text(
             text = stringResource(id = R.string.newsletter_detail_summary_title),
             style = androidx.compose.ui.text.TextStyle(
-                color = Color.Black,
+                color = MaterialTheme.colorScheme.onSurface,
                 fontSize = 24.sp,
                 fontFamily = SfPro,
                 fontWeight = FontWeight.Bold,
@@ -78,7 +80,7 @@ fun NewsletterDetailComponent(newsletter: Newsletter) {
             ),
             textAlign = TextAlign.Center,
             style = androidx.compose.ui.text.TextStyle(
-                color = Color.Black,
+                color = MaterialTheme.colorScheme.onSurface,
                 fontSize = 16.sp,
                 fontFamily = SfPro,
                 fontStyle = FontStyle.Italic,


### PR DESCRIPTION
Makes the app's dark mode more readable. Some icons in VacationPage should still be changed to a dark color equivalent.

Closes #108 