### PR TITLE
feat(app_modal_android): adding the about part in sidebar

### DIFF
--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/components/Layout.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/components/Layout.kt
@@ -17,11 +17,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.zIndex
 import androidx.navigation.NavController
 import com.xpeho.xpeapp.ui.Measurements
 import com.xpeho.xpeapp.ui.components.layout.Header
 import com.xpeho.xpeapp.ui.components.layout.Sidebar
+import com.xpeho.xpeapp.ui.page.about.AboutView
 
 @Composable
 fun Layout(
@@ -31,6 +33,8 @@ fun Layout(
     val sidebarVisible = remember {
         mutableStateOf(false)
     }
+    val showDialog = remember { mutableStateOf(false) }
+
 
     Box(
         modifier = Modifier
@@ -63,21 +67,23 @@ fun Layout(
             ) {
                 Sidebar(
                     navigationController = navigationController,
-                    sidebarVisible = sidebarVisible
+                    sidebarVisible = sidebarVisible,
+                    showDialog = showDialog
                 )
             }
         }
 
-        // Content
         Column(
             modifier = Modifier
                 .fillMaxSize(),
             verticalArrangement = Arrangement.Top,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            // Header
             Header(sidebarVisible = sidebarVisible)
             child()
         }
+    }
+    if (showDialog.value) {
+        AboutView(onDismiss = { showDialog.value = false }, context = LocalContext.current)
     }
 }

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/components/layout/Sidebar.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/components/layout/Sidebar.kt
@@ -1,8 +1,5 @@
 package com.xpeho.xpeapp.ui.components.layout
 
-import SidebarItemProfile
-import android.content.Intent
-import android.net.Uri
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
@@ -14,17 +11,14 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
@@ -32,34 +26,24 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
-import com.xpeho.xpeapp.BuildConfig
 import com.xpeho.xpeapp.R
 import com.xpeho.xpeapp.XpeApp
 import com.xpeho.xpeapp.enums.Screens
-import com.xpeho.xpeapp.ui.Measurements
 import com.xpeho.xpeapp.ui.Resources
-import com.xpeho.xpeho_ui_android.ClickyButton
-import com.xpeho.xpeho_ui_android.foundations.Fonts
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import com.xpeho.xpeho_ui_android.R.drawable as XpehoRes
 import com.xpeho.xpeho_ui_android.foundations.Colors as XpehoColors
 
 @Composable
 fun Sidebar(
     navigationController: NavController,
-    sidebarVisible: MutableState<Boolean>
+    sidebarVisible: MutableState<Boolean>,
+    showDialog: MutableState<Boolean>
 ) {
-    // Feature Flipping
-    val context = LocalContext.current
+
     val ffManager = XpeApp.appModule.featureFlippingManager
 
     // Computed sidebar size
@@ -79,7 +63,6 @@ fun Sidebar(
             .fillMaxHeight()
             .fillMaxWidth(sidebarWidth)
             .background(color = XpehoColors.XPEHO_COLOR)
-            // Prevent clickable element under the sidebar to be triggered on click
             .clickable(
                 indication = null,
                 interactionSource = remember { MutableInteractionSource() }
@@ -95,7 +78,6 @@ fun Sidebar(
                     .fillMaxHeight(),
                 verticalArrangement = Arrangement.SpaceBetween
             ) {
-
                 Column {
                     IconButton(
                         onClick = {
@@ -121,7 +103,7 @@ fun Sidebar(
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .background(Color.Black.copy(alpha = 0.1f)) // Arrière-plan noir avec 10% d'opacité
+                            .background(Color.Black.copy(alpha = 0.1f))
                     ) {
                         SidebarItemProfile(
                             navigationController = navigationController,
@@ -133,15 +115,16 @@ fun Sidebar(
                             .height(20.dp)
                     )
 
-                    Column (
+                    Column(
                         modifier = Modifier
                             .padding(horizontal = 18.dp),
                     ) {
                         SidebarItem(
-                            navigationController = navigationController,
                             icon = painterResource(id = R.drawable.home),
                             label = "Accueil",
-                            route = Screens.Home.name
+                            onClick = {
+                                navigationController.navigate(Screens.Home.name)
+                            }
                         )
                         Spacer(
                             modifier = Modifier
@@ -150,91 +133,29 @@ fun Sidebar(
                         for (menuItem in Resources().listOfMenu) {
                             if (ffManager.isFeatureEnabled(menuItem.featureFlippingId)) {
                                 SidebarItem(
-                                    navigationController = navigationController,
                                     icon = painterResource(id = menuItem.idImage),
                                     label = menuItem.title,
-                                    route = menuItem.redirection
+                                    onClick = {
+                                        navigationController.navigate(menuItem.redirection)
+                                    }
                                 )
                                 Spacer(
                                     modifier = Modifier
                                         .height(20.dp)
                                 )
                             }
-                        } }
-
+                        }
+                        SidebarItem(
+                            icon = painterResource(id = R.drawable.about),
+                            label = stringResource(id = R.string.about_view_about_label),
+                            onClick = {
+                                sidebarVisible.value = false
+                                showDialog.value = true
+                            }
+                        )
+                    }
                 }
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier
-                        .padding(bottom = 20.dp, start = 18.dp, end = 18.dp),
-                ) {
-                    HorizontalDivider(
-                        color = Color.White,
-                        thickness = 1.dp,
-                        modifier = Modifier
-                            .fillMaxWidth(Measurements.SIDEBAR_DIVIDER_PERCENTAGE)
-                            .padding(bottom = 10.dp, top = 20.dp)
-                    )
-                    SidebarInfoSection(context)
-                    SidebarConfidentialityButton(context)
-                }
-
-
             }
         }
-    }
-}
-
-
-@Composable
-fun SidebarInfoSection(
-    context: android.content.Context
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
-        val versionCode = BuildConfig.VERSION_NAME
-        Subtitle(
-            label = "by XPEHO",
-            modifier = Modifier
-                .clickable {
-                    // Open the XPEHO website
-                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://www.xpeho.com"))
-                    context.startActivity(intent)
-                }
-        )
-        Subtitle(label = "v$versionCode")
-    }
-}
-
-@Composable
-fun SidebarConfidentialityButton(
-    context: android.content.Context
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth(),
-        horizontalArrangement = Arrangement.Center
-    ) {
-        Text(
-            text = "Politiques de confidentialité",
-            fontSize = 14.sp,
-            fontFamily = Fonts.raleway,
-            fontWeight = FontWeight.Bold,
-            textDecoration = TextDecoration.Underline,
-            color = Color.White,
-            modifier = Modifier
-                .clickable {
-                    // Open the confidentiality page
-                    val intent =
-                        Intent(
-                            Intent.ACTION_VIEW,
-                            Uri.parse("https://github.com/XPEHO/XpeApp/blob/main/PRIVACY_POLICY.md")
-                        )
-                    context.startActivity(intent)
-                }
-        )
     }
 }

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/components/layout/SidebarItem.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/components/layout/SidebarItem.kt
@@ -11,19 +11,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
 
 @Composable
 fun SidebarItem(
-    navigationController: NavController,
     icon: Painter,
     label: String,
-    route: String
+    onClick: () -> Unit
 ) {
     Row(
         modifier = Modifier
             .clickable {
-                navigationController.navigate(route = route)
+                onClick()
             }
     ) {
         Icon(

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/components/layout/SidebarItemProfile.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/components/layout/SidebarItemProfile.kt
@@ -1,3 +1,5 @@
+package com.xpeho.xpeapp.ui.components.layout
+
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Icon
@@ -11,7 +13,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.xpeho.xpeapp.enums.Screens
-import com.xpeho.xpeapp.ui.components.layout.Subtitle
 import com.xpeho.xpeapp.ui.uiState.UserInfosUiState
 import com.xpeho.xpeapp.ui.viewModel.user.UserInfosViewModel
 import com.xpeho.xpeho_ui_android.foundations.Fonts

--- a/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/page/about/AboutView.kt
+++ b/xpeapp_android/app/src/main/java/com/xpeho/xpeapp/ui/page/about/AboutView.kt
@@ -1,0 +1,122 @@
+package com.xpeho.xpeapp.ui.page.about
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.xpeho.xpeapp.BuildConfig
+import com.xpeho.xpeapp.R
+import com.xpeho.xpeho_ui_android.ClickyButton
+import com.xpeho.xpeho_ui_android.foundations.Colors
+import com.xpeho.xpeho_ui_android.foundations.Fonts
+
+@Composable
+fun AboutView(onDismiss: () -> Unit, context: Context) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 8.dp)
+            ) {
+                Text(text = stringResource(id = R.string.about_view_about_label)
+                    , fontWeight = FontWeight.Bold, fontSize = 18.sp)
+            }
+        },
+        text = {
+            Column(modifier = Modifier.padding(8.dp)) {
+                SidebarInfoSection(context)
+                Spacer(modifier = Modifier.height(8.dp))
+                SidebarConfidentialityButton(context)
+            }
+        },
+        confirmButton = {
+            Box (
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center
+            ){
+                ClickyButton(
+                    label = stringResource(id = R.string.about_view_ok_label),
+                    size = 16.sp,
+                    backgroundColor = Colors.XPEHO_COLOR,
+                    labelColor = Color.White,
+                    verticalPadding = 8.dp,
+                    horizontalPadding = 16.dp,
+                    enabled = true,
+                    onPress = onDismiss
+                )
+            }
+        }
+    )
+}
+
+@Composable
+fun SidebarInfoSection(context: Context) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = stringResource(id = R.string.about_view_propriety_label),
+                fontSize = 16.sp,
+                fontFamily = Fonts.raleway,
+                fontWeight = FontWeight.Bold,
+                color = Color.Black,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "XPEHO",
+                fontSize = 16.sp,
+                fontFamily = Fonts.raleway,
+                fontWeight = FontWeight.Bold,
+                textDecoration = TextDecoration.Underline,
+                color = Color.Black,
+                modifier = Modifier.clickable {
+                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://www.xpeho.com"))
+                    context.startActivity(intent)
+                }
+            )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = stringResource(id = R.string.about_view_version_label)
+                    + " " + BuildConfig.VERSION_NAME,
+            fontSize = 16.sp,
+            fontFamily = Fonts.raleway,
+            fontWeight = FontWeight.Bold,
+            color = Color.Black,
+        )
+    }
+}
+
+@Composable
+fun SidebarConfidentialityButton(context: Context) {
+    Text(
+        text = stringResource(id = R.string.about_view_confidentiality_label),
+        fontSize = 14.sp,
+        fontFamily = Fonts.raleway,
+        fontWeight = FontWeight.Bold,
+        textDecoration = TextDecoration.Underline,
+        color = Color.Black,
+        modifier = Modifier.clickable {
+            val intent = Intent(
+                Intent.ACTION_VIEW,
+                Uri.parse("https://github.com/XPEHO/XpeApp/blob/main/PRIVACY_POLICY.md")
+            )
+            context.startActivity(intent)
+        }
+    )
+}

--- a/xpeapp_android/app/src/main/res/values/strings.xml
+++ b/xpeapp_android/app/src/main/res/values/strings.xml
@@ -59,4 +59,10 @@
     <string name="profil_page_modify_password_loading_message">Chargement des données…</string>
     <string name="profil_page_modify_password_content_description_edit_password">ModificationDuMotDePassePage</string>
     <string name="profil_page_modify_password_content_description_profile">PageDeProfile</string>
+    <string name="about_view_about_label">À propos</string>
+    <string name="about_view_ok_label">OK</string>
+    <string name="about_view_version_label">Version: </string>
+    <string name="about_view_confidentiality_label">Politiques de confidentialité</string>
+    <string name="about_view_propriety_label">Propriétaire:</string>
+
 </resources>


### PR DESCRIPTION
# Description
Sidebar : 
<img width="236" alt="image" src="https://github.com/user-attachments/assets/3eba73cc-bbf0-4670-a54a-24d63d593eb3" />

Pop up: 
<img width="408" alt="image" src="https://github.com/user-attachments/assets/eab27df8-1596-4014-b60a-e662dc0ea13e" />

Video : 
https://github.com/user-attachments/assets/7d1d19ab-3c9f-4413-8b0f-d2388a301468

# Linked Issues
What are the issues fixed by this pull request ?

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [X] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
