### PR TITLE
chore(sonar): add manual trigger

### DIFF
--- a/.github/workflows/sonar_android.yaml
+++ b/.github/workflows/sonar_android.yaml
@@ -9,6 +9,12 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - "xpeapp_android/**"
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for running the workflow'
+        required: true
+        default: 'Manually triggered'
 
 name: Sonar Android
 jobs:

--- a/.github/workflows/sonar_ios.yaml
+++ b/.github/workflows/sonar_ios.yaml
@@ -9,6 +9,12 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - "xpeapp_ios/**"
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for running the workflow'
+        required: true
+        default: 'Manually triggered'
 
 name: Sonar IOS
 jobs:


### PR DESCRIPTION
This pull request includes changes to the GitHub workflows for both Android and iOS projects to allow manual triggering with a specified reason.

Changes to GitHub workflows:

* [`.github/workflows/sonar_android.yaml`](diffhunk://#diff-7de6d97701e1ad92493a784cd055eb3cf400a0d16007ee9462aabeb4a47f18b9R12-R17): Added `workflow_dispatch` event to allow manual triggering with a required input for the reason.
* [`.github/workflows/sonar_ios.yaml`](diffhunk://#diff-e78634677e2911978a36104ab0c42219369ab31144179476021fcd652543b559R12-R17): Added `workflow_dispatch` event to allow manual triggering with a required input for the reason.